### PR TITLE
Some fixes to make the openaire-cris-validator more happy

### DIFF
--- a/meresco/servers/api/apiserver.py
+++ b/meresco/servers/api/apiserver.py
@@ -116,7 +116,7 @@ def createDownloadHelix(reactor, periodicDownload, oaiDownload, storageComponent
                     (FilterMessages(allowed=['add']),
                         (XmlXPath(['/oai:record/oai:metadata/document:document/document:part[@name="record"]/text()'], fromKwarg='lxmlNode', toKwarg='data', namespaces=NAMESPACEMAP),
                             (XmlParseLxml(fromKwarg='data', toKwarg='lxmlNode'),
-                                    
+
                                 (FilterWcpCollection(allowed=['research']),
                                     (XmlXPath(['/oai:record/oai:metadata/norm:md_original/child::*'], fromKwarg='lxmlNode', namespaces=NAMESPACEMAP), # Origineel 'metadata' formaat
                                         (XsltCrosswalk([join(dirname(abspath(__file__)), '..', '..', 'xslt', 'cerif-project.xsl')], fromKwarg="lxmlNode"),
@@ -129,7 +129,7 @@ def createDownloadHelix(reactor, periodicDownload, oaiDownload, storageComponent
                                     )
                                 ),
 
-                                (FilterWcpCollection(allowed=['person']),                                    
+                                (FilterWcpCollection(allowed=['person']),
                                     (XmlXPath(['/oai:record/oai:metadata/norm:md_original/child::*'], fromKwarg='lxmlNode', namespaces=NAMESPACEMAP), # Origineel 'metadata' formaat
                                         (XsltCrosswalk([join(dirname(abspath(__file__)), '..', '..', 'xslt', 'cerif-person.xsl')], fromKwarg="lxmlNode"),
                                             (RewritePartname(OPENAIRE_PARTNAME),
@@ -225,18 +225,18 @@ def createDownloadHelix(reactor, periodicDownload, oaiDownload, storageComponent
                                 # Add NOD OpenAIRE Cerif to OpenAIRE-PMH repo.
                                 (FilterWcpCollection(allowed=['research']),
                                     # (LogComponent("RESEARCH ADD:"),),
-                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_projects']),
+                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_projects'], name=['OpenAIRE_CRIS_projects']),
                                         # (LogComponent("RESEARCH ADD:"),),
                                         (oai_oa_cerifJazz,),
                                     )
                                 ),
                                 (FilterWcpCollection(allowed=['person']),
-                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_persons']),
+                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_persons'], name=['OpenAIRE_CRIS_persons']),
                                         (oai_oa_cerifJazz,),
                                     )
                                 ),
                                 (FilterWcpCollection(allowed=['organisation']),
-                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_orgunits']),
+                                    (OaiAddDeleteRecordWithPrefixesAndSetSpecs(metadataPrefixes=[OPENAIRE_PARTNAME], setSpecs=['openaire_cris_orgunits'], name=['OpenAIRE_CRIS_orgunits']),
                                         (oai_oa_cerifJazz,),
                                     )
                                 )
@@ -283,16 +283,16 @@ def main(reactor, port, statePath, lucenePort, gatewayPort, quickCommit=False, *
     defaultLuceneSettings = LuceneSettings(
         commitTimeout=30,
         readonly=True,)
-    
-    
+
+
     http11Request = be(
         (HttpRequest1_1(),
             (SocketPool(reactor=reactor, unusedTimeout=5, limits=dict(totalSize=100, destinationSize=10)),),
         )
     )
-    
+
     luceneIndex = luceneAndReaderConfig(defaultLuceneSettings.clone(readonly=True), http11Request, lucenePort)
-    
+
     luceneRoHelix = be(
         (AdapterToLuceneQuery(
                 defaultCore=DEFAULT_CORE,
@@ -390,13 +390,13 @@ def main(reactor, port, statePath, lucenePort, gatewayPort, quickCommit=False, *
                             (storage,)
                         ),
                         (OaiBranding(
-                            url="http://www.narcis.nl/images/logos/logo-knaw-house.gif", 
-                            link="http://oai.narcis.nl", 
+                            url="http://www.narcis.nl/images/logos/logo-knaw-house.gif",
+                            link="http://oai.narcis.nl",
                             title="Narcis - The gateway to scholarly information in The Netherlands"),
                         ),
                         (OaiProvenance(
                             nsMap=NAMESPACEMAP,
-                            baseURL=('meta', '//meta:repository/meta:baseurl/text()'), 
+                            baseURL=('meta', '//meta:repository/meta:baseurl/text()'),
                             harvestDate=('meta', '//meta:record/meta:harvestdate/text()'),
                             metadataNamespace=('meta', '//meta:record/meta:metadataNamespace/text()'),
                             identifier=('header','//oai:identifier/text()'),
@@ -424,13 +424,13 @@ def main(reactor, port, statePath, lucenePort, gatewayPort, quickCommit=False, *
                             owneracronym='NARCIS'),
                         ),
                         # (OaiBranding(
-                        #     url="http://www.narcis.nl/images/logos/logo-knaw-house.gif", 
-                        #     link="http://oai.narcis.nl", 
+                        #     url="http://www.narcis.nl/images/logos/logo-knaw-house.gif",
+                        #     link="http://oai.narcis.nl",
                         #     title="Narcis - The gateway to scholarly information in The Netherlands"),
                         # ),
                         (OaiProvenance(
                             nsMap=NAMESPACEMAP,
-                            baseURL=('meta', '//meta:repository/meta:baseurl/text()'), 
+                            baseURL=('meta', '//meta:repository/meta:baseurl/text()'),
                             harvestDate=('meta', '//meta:record/meta:harvestdate/text()'),
                             metadataNamespace=('meta', '//meta:record/meta:metadataNamespace/text()'),
                             identifier=('header','//oai:identifier/text()'),
@@ -468,11 +468,11 @@ def main(reactor, port, statePath, lucenePort, gatewayPort, quickCommit=False, *
                             maximumRecords = 20),
                         executeQueryHelix,
                         (RssItem(
-                                nsMap=NAMESPACEMAP,                                            
+                                nsMap=NAMESPACEMAP,
                                 title = ('knaw_short', {'nl':'//short:metadata/short:titleInfo[not (@xml:lang)]/short:title/text()', 'en':'//short:metadata/short:titleInfo[@xml:lang="en"]/short:title/text()'}),
                                 description = ('knaw_short', {'nl':'//short:abstract[not (@xml:lang)]/text()', 'en':'//short:abstract[@xml:lang="en"]/text()'}),
                                 pubdate = ('knaw_short', '//short:dateIssued/short:parsed/text()'),
-                                linkTemplate = 'http://www.narcis.nl/%(wcpcollection)s/RecordID/%(oai_identifier)s/Language/%(language)s',                                
+                                linkTemplate = 'http://www.narcis.nl/%(wcpcollection)s/RecordID/%(oai_identifier)s/Language/%(language)s',
                                 wcpcollection = ('meta', '//*[local-name() = "collection"]/text()'),
                                 oai_identifier = ('meta', '//meta:record/meta:id/text()'),
                                 language = ('Dummy: Language is auto provided by the calling RSS component, but needs to be present to serve the linkTemplate.')

--- a/meresco/xslt/cerif-orgunit.xsl
+++ b/meresco/xslt/cerif-orgunit.xsl
@@ -41,7 +41,7 @@
 
     <xsl:template match="input:identifier">
         <xsl:attribute name="id">
-            <xsl:value-of select="concat('oai:narcis.nl:organisation:', .)"/>
+            <xsl:value-of select="concat('oai:narcis.nl:OrgUnits/', .)"/>
         </xsl:attribute>
     </xsl:template>
 

--- a/meresco/xslt/cerif-person.xsl
+++ b/meresco/xslt/cerif-person.xsl
@@ -36,7 +36,7 @@
 
     <xsl:template match="input:identifier">
         <xsl:attribute name="id">
-            <xsl:value-of select="concat('oai:narcis.nl:person:', .)"/>
+            <xsl:value-of select="concat('oai:narcis.nl:Persons/', .)"/>
         </xsl:attribute>
     </xsl:template>
 

--- a/meresco/xslt/cerif-project.xsl
+++ b/meresco/xslt/cerif-project.xsl
@@ -58,7 +58,7 @@
 
     <xsl:template match="input:identifier">
         <xsl:attribute name="id">
-            <xsl:value-of select="concat('oai:narcis.nl:research:', .)"/>
+            <xsl:value-of select="concat('oai:narcis.nl:Project/', .)"/>
         </xsl:attribute>
     </xsl:template>
 

--- a/meresco/xslt/cerif-project.xsl
+++ b/meresco/xslt/cerif-project.xsl
@@ -58,7 +58,7 @@
 
     <xsl:template match="input:identifier">
         <xsl:attribute name="id">
-            <xsl:value-of select="concat('oai:narcis.nl:Project/', .)"/>
+            <xsl:value-of select="concat('oai:narcis.nl:Projects/', .)"/>
         </xsl:attribute>
     </xsl:template>
 

--- a/test/_integration/apitest.py
+++ b/test/_integration/apitest.py
@@ -67,7 +67,7 @@ class ApiTest(IntegrationTestCase):
             u'\u042d\u043a\u043e\u043b\u043e\u0433\u043e-\u0440\u0435\u043a\u0440\u0435\u0430\u0446\u0438\u043e\u043d\u043d\u044b\u0439 \u043a\u043e\u0440\u0438\u0434\u043e\u0440 \u0432 \u0433\u043e\u0440\u043d\u043e\u043c \u0437\u0430\u043f\u043e\u0432\u0435\u0434\u043d\u0438\u043a\u0435 \u0411\u043e\u0433\u043e\u0442\u044b' }, set(testNamespaces.xpath(response, '//short:metadata/short:titleInfo[1]/short:title/text()')))
 
     def testSruQueryWithUntokenized(self):
-        response = self.doSruQuery(**{"query": 'untokenized.humanstartpage exact "http://meresco.com?record=1"', "recordSchema": "knaw_long"})        
+        response = self.doSruQuery(**{"query": 'untokenized.humanstartpage exact "http://meresco.com?record=1"', "recordSchema": "knaw_long"})
         # print "humanStartPage:", etree.tostring(response)
         self.assertEqual('meresco:record:1', xpathFirst(response, '//srw:recordIdentifier/text()'))
         response = self.doSruQuery(**{"query": 'untokenized.dd_year exact "2016"'})
@@ -114,8 +114,8 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('rce:rapporten:550000001', xpathFirst(response, '//srw:recordIdentifier/text()'))
 #         print "DD body:", etree.tostring(response)
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
-    
-        
+
+
     def testNODPRSnameIdentifiers(self):
         self.assertSruQuery(2, '"PRS1242583"')
         self.assertSruQuery(2, '0000000247033788')
@@ -211,6 +211,7 @@ class ApiTest(IntegrationTestCase):
         header, body = getRequest(self.apiPort, '/cerif_oa', dict(verb="ListSets"))
         # print "ListSets", etree.tostring(body)
         self.assertEqual({'openaire_cris_persons','openaire_cris_projects','openaire_cris_orgunits'}, set(xpath(body, '//oai:setSpec/text()')))
+        self.assertEqual({'OpenAIRE_CRIS_persons','OpenAIRE_CRIS_projects','OpenAIRE_CRIS_orgunits'}, set(xpath(body, '//oai:setName/text()')))
 
     def testOaiListSets(self):
         header, body = getRequest(self.apiPort, '/oai', dict(verb="ListSets"))
@@ -221,12 +222,12 @@ class ApiTest(IntegrationTestCase):
         header, body = getRequest(self.apiPort, '/oai', dict(verb="ListMetadataFormats"))
         #print "ListMetadataFormats", etree.tostring(body)
         self.assertEqual({'oai_dc'}, set(xpath(body, '//oai:metadataFormat/oai:metadataPrefix/text()')))
-        
+
     def testOaiCerifListMetadataFormats(self):
         header, body = getRequest(self.apiPort, '/cerif_oa', dict(verb="ListMetadataFormats"))
         #print "ListMetadataFormats", etree.tostring(body)
         self.assertEqual({'oai_cerif_openaire'}, set(xpath(body, '//oai:metadataFormat/oai:metadataPrefix/text()')))
-        
+
 
     def testRSS(self):
         header, body = getRequest(self.apiPort, '/rss', dict(query="*", querylabel='MyLabel', sortKeys='untokenized.dateissued,,0', startRecord='4'))
@@ -277,7 +278,7 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual(10, len(testNamespaces.xpath(response, '//long:metadata/long:subject/long:topic')))
         self.assertEqual(2, len(testNamespaces.xpath(response, '//long:metadata/long:coverage')))
         self.assertEqual(4, len(testNamespaces.xpath(response, '//long:metadata/long:format')))
-    
+
     def testModsToLong(self):
         response = self.doSruQuery(**{'query': 'URN:NBN:NL:UI:17-565', 'recordSchema':'knaw_long'})
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
@@ -318,8 +319,8 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual(1, len(testNamespaces.xpath(response, '//long:metadata/long:rightsDescription')))
         self.assertEqual(1, len(testNamespaces.xpath(response, '//long:metadata/long:subject[@xml:lang="en"]/long:topic')))
         self.assertEqual(2, len(testNamespaces.xpath(response, '//long:metadata/long:grantAgreements/long:grantAgreement')))
- 
-    
+
+
     def testMods3xToLong(self):
         response = self.doSruQuery(**{'query': 'urn:NBN:nl:ui:18-2271', 'recordSchema':'knaw_long'}) # knaw_record2_didlmods
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
@@ -359,12 +360,12 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual(1, len(testNamespaces.xpath(response, '//long:metadata/long:rightsDescription')))
         self.assertEqual(7, len(testNamespaces.xpath(response, '//long:metadata/long:subject/long:topic')))
         self.assertEqual(3, len(testNamespaces.xpath(response, '//long:metadata/long:grantAgreements/long:grantAgreement')))
-        
+
         response = self.doSruQuery(**{'query': 'URN:NBN:NL:UI:25-711504', 'recordSchema':'knaw_long'}) # TODO find exact op pubid
         #print etree.tostring(response)
         self.assertEqual('restrictedAccess', testNamespaces.xpathFirst(response, '//long:objectFiles/long:objectFile/long:accessRights/text()'))
         self.assertEqual('restrictedAccess', testNamespaces.xpathFirst(response, '//long:knaw_long/long:accessRights/text()'))
- 
+
     def testDataciteToLong(self):
         response = self.doSruQuery(**{'query': 'urn:nbn:nl:ui:13-jsk-7ek', 'recordSchema':'knaw_long'})
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
@@ -411,14 +412,14 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('research', testNamespaces.xpathFirst(response, '//short:metadata/short:genre/text()'))
         self.assertEqual('Projectomschrijving<br>Ontwikkeling van betrouwbare methoden,', testNamespaces.xpathFirst(response, '//short:metadata/short:abstract/text()')[:61])
         self.assertEqual(2, len(testNamespaces.xpath(response, '//short:metadata/short:titleInfo/short:title')))
-     
+
     def testOrganisationToShort(self):
         response = self.doSruQuery(**{'query': 'ORG1236141', 'recordSchema':'knaw_short'})
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
         self.assertEqual('Wetenschapswinkel', testNamespaces.xpathFirst(response, '//short:metadata/short:titleInfo/short:title/text()'))
         self.assertEqual('organisation', testNamespaces.xpathFirst(response, '//short:metadata/short:genre/text()'))
         self.assertEqual(2, len(testNamespaces.xpath(response, '//short:metadata/short:titleInfo/short:title')))
-     
+
     def testPersonToShort(self):
         response = self.doSruQuery(**{'query': 'person:PRS1242583', 'recordSchema':'knaw_short'})
         self.assertEqual(1, int(str(xpathFirst(response, '//srw:numberOfRecords/text()'))))
@@ -432,7 +433,7 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('0000-0002-4703-3788', testNamespaces.xpathFirst(response, '//short:metadata/short:name/short:nameIdentifier[@type="orcid"]/text()'))
         self.assertEqual('PRS1242583', testNamespaces.xpathFirst(response, '//short:metadata/short:name/short:nameIdentifier[@type="nod-prs"]/text()'))
         self.assertEqual(4, len(testNamespaces.xpath(response, '//short:metadata/short:name/short:nameIdentifier')))
-     
+
 
     def assertSruQuery(self, numberOfRecords, query, printout=False):
         response = self.doSruQuery(**{'query':query, "recordSchema": "knaw_short", "x-recordSchema": "header"}) # , 'maximumRecords': '1'


### PR DESCRIPTION
Based on the output of the [openaire-cris-validator](https://github.com/jdvorak001/openaire-cris-validator), I added/changed a couple of things related to the CERIF OAI output. In particular:

1. I added `name` parameters to the `OaiAddDeleteRecordWithPrefixesAndSetSpecs`, such that
    ```xml
    <set>
        <setSpec>openaire_cris_projects</setSpec>
        <setName/>
    </set>
    ```
    would become
    ```xml
    <set>
        <setSpec>openaire_cris_projects</setSpec>
        <setName> OpenAIRE_CRIS_projects </setName>
    </set>
    ```
    and the others as well, with their own name. Also added an extra unit test for this.
2. I changed the ID prefix:
    1. from `'oai:narcis.nl:organisation:'` to `'oai:narcis.nl:OrgUnits/'`
    2. from `'oai:narcis.nl:person:'` to `'oai:narcis.nl:Persons/'`
    3. from `'oai:narcis.nl:research:'` to `'oai:narcis.nl:Projects/'`
3. Sorry for the weird formatting changes. That's not me, but IntelliJ somehow insisted on removing all these spaces. Don't know why or how to tell it not to do so.

**_Please note: I have no clue how to test this, either by running the unit tests or by deploying it to the test server and running the validator again. So this is literally a shot into the dark. If it doesn't work, feel free to reject this PR or fix it yourself while I'm gone._**

@DANS-KNAW/narcis @wilkos-dans for review