### PR TITLE
Validator feedback

### DIFF
--- a/meresco/xslt/cerif-orgunit.xsl
+++ b/meresco/xslt/cerif-orgunit.xsl
@@ -55,17 +55,17 @@
 
     <xsl:template match="input:naam_nl">
         <xsl:if test=".">
-            <Naam xml:lang="nl">
+            <Name xml:lang="nl">
                 <xsl:value-of select="."/>
-            </Naam>
+            </Name>
         </xsl:if>
     </xsl:template>
 
     <xsl:template match="input:naam_en">
         <xsl:if test=".">
-            <Naam xml:lang="en">
+            <Name xml:lang="en">
                 <xsl:value-of select="."/>
-            </Naam>
+            </Name>
         </xsl:if>
     </xsl:template>
 

--- a/meresco/xslt/cerif-person.xsl
+++ b/meresco/xslt/cerif-person.xsl
@@ -27,7 +27,10 @@
             <xsl:apply-templates select="input:initials"/>
         </PersonName>
 
-        <xsl:apply-templates select="input:nameIdentifier"/>
+        <xsl:apply-templates select="input:nameIdentifier[@type='orcid'][1]"/>
+        <xsl:apply-templates select="input:nameIdentifier[@type='rid'][1]"/>
+        <xsl:apply-templates select="input:nameIdentifier[@type='said'][1]"/>
+        <xsl:apply-templates select="input:nameIdentifier[@type='isni'][1]"/>
 
         <xsl:apply-templates select="input:person_url"/>
 
@@ -56,75 +59,73 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="input:nameIdentifier">
-        <xsl:choose>
-            <xsl:when test="@type='orcid'">
-                <xsl:variable name="orcid1">
-                    <xsl:value-of select="substring(., 1, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="orcid2">
-                    <xsl:value-of select="substring(., 5, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="orcid3">
-                    <xsl:value-of select="substring(., 9, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="orcid4">
-                    <xsl:value-of select="substring(., 13, 4)"/>
-                </xsl:variable>
-                <ORCID>
-                    <xsl:text>https://orcid.org/</xsl:text>
-                    <xsl:value-of select="normalize-space($orcid1)"/>
-                    <xsl:text>-</xsl:text>
-                    <xsl:value-of select="normalize-space($orcid2)"/>
-                    <xsl:text>-</xsl:text>
-                    <xsl:value-of select="normalize-space($orcid3)"/>
-                    <xsl:text>-</xsl:text>
-                    <xsl:value-of select="normalize-space($orcid4)"/>
-                </ORCID>
-            </xsl:when>
-            <xsl:when test="@type='isni'">
-                <xsl:variable name="isni1">
-                    <xsl:value-of select="substring(., 1, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="isni2">
-                    <xsl:value-of select="substring(., 5, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="isni3">
-                    <xsl:value-of select="substring(., 9, 4)"/>
-                </xsl:variable>
-                <xsl:variable name="isni4">
-                    <xsl:value-of select="substring(., 13, 4)"/>
-                </xsl:variable>
-                <ISNI>
-                    <xsl:value-of select="normalize-space($isni1)"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="normalize-space($isni2)"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="normalize-space($isni3)"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="normalize-space($isni4)"/>
-                </ISNI>
-            </xsl:when>
-            <xsl:when test="@type='rid'">
-                <!--
-                    TODO when adding the ResearcherID, this number must be properly formatted
-                    we don't know yet what the format is gonna look like from the NOD OAI-PMH output
-                  -->
-                <ResearcherID>
-                    <xsl:value-of select="."/>
-                </ResearcherID>
-            </xsl:when>
-            <xsl:when test="@type='said'">
-                <!--
-                    TODO when adding the ScopusAuthorID, this number must be properly formatted
-                    we don't know yet what the format is gonna look like from the NOD OAI-PMH output
-                  -->
-                <ScopusAuthorID>
-                    <xsl:value-of select="."/>
-                </ScopusAuthorID>
-            </xsl:when>
-        </xsl:choose>
+    <xsl:template match="input:nameIdentifier[@type='orcid']">
+        <xsl:variable name="orcid1">
+            <xsl:value-of select="substring(., 1, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="orcid2">
+            <xsl:value-of select="substring(., 5, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="orcid3">
+            <xsl:value-of select="substring(., 9, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="orcid4">
+            <xsl:value-of select="substring(., 13, 4)"/>
+        </xsl:variable>
+        <ORCID>
+            <xsl:text>https://orcid.org/</xsl:text>
+            <xsl:value-of select="normalize-space($orcid1)"/>
+            <xsl:text>-</xsl:text>
+            <xsl:value-of select="normalize-space($orcid2)"/>
+            <xsl:text>-</xsl:text>
+            <xsl:value-of select="normalize-space($orcid3)"/>
+            <xsl:text>-</xsl:text>
+            <xsl:value-of select="normalize-space($orcid4)"/>
+        </ORCID>
+    </xsl:template>
 
+    <xsl:template match="input:nameIdentifier[@type='isni']">
+        <xsl:variable name="isni1">
+            <xsl:value-of select="substring(., 1, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="isni2">
+            <xsl:value-of select="substring(., 5, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="isni3">
+            <xsl:value-of select="substring(., 9, 4)"/>
+        </xsl:variable>
+        <xsl:variable name="isni4">
+            <xsl:value-of select="substring(., 13, 4)"/>
+        </xsl:variable>
+        <ISNI>
+            <xsl:value-of select="normalize-space($isni1)"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="normalize-space($isni2)"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="normalize-space($isni3)"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="normalize-space($isni4)"/>
+        </ISNI>
+    </xsl:template>
+
+    <xsl:template match="input:nameIdentifier[@type='rid']">
+        <!--
+            TODO when adding the ResearcherID, this number must be properly formatted
+            we don't know yet what the format is gonna look like from the NOD OAI-PMH output
+          -->
+        <ResearcherID>
+            <xsl:value-of select="."/>
+        </ResearcherID>
+    </xsl:template>
+
+    <xsl:template match="input:nameIdentifier[@type='said']">
+        <!--
+            TODO when adding the ScopusAuthorID, this number must be properly formatted
+            we don't know yet what the format is gonna look like from the NOD OAI-PMH output
+          -->
+        <ScopusAuthorID>
+            <xsl:value-of select="."/>
+        </ScopusAuthorID>
     </xsl:template>
 
     <xsl:template match="input:person_url">

--- a/meresco/xslt/cerif-project.xsl
+++ b/meresco/xslt/cerif-project.xsl
@@ -132,31 +132,37 @@
 
     <xsl:template match="input:penvoerder">
         <xsl:if test=".">
-            <OrgUnit>
-                <xsl:attribute name="id">
-                    <xsl:value-of select="@code"/>
-                </xsl:attribute>
-            </OrgUnit>
+            <Coordinator>
+                <OrgUnit>
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="@code"/>
+                    </xsl:attribute>
+                </OrgUnit>
+            </Coordinator>
         </xsl:if>
     </xsl:template>
 
     <xsl:template match="input:samenwerking">
         <xsl:if test=".">
-            <OrgUnit>
-                <xsl:attribute name="id">
-                    <xsl:value-of select="@code"/>
-                </xsl:attribute>
-            </OrgUnit>
+            <Partner>
+                <OrgUnit>
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="@code"/>
+                    </xsl:attribute>
+                </OrgUnit>
+            </Partner>
         </xsl:if>
     </xsl:template>
 
     <xsl:template match="input:opdrachtgever">
         <xsl:if test=".">
-            <OrgUnit>
-                <xsl:attribute name="id">
-                    <xsl:value-of select="@code"/>
-                </xsl:attribute>
-            </OrgUnit>
+            <Member>
+                <OrgUnit>
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="@code"/>
+                    </xsl:attribute>
+                </OrgUnit>
+            </Member>
         </xsl:if>
     </xsl:template>
 


### PR DESCRIPTION
**Change in `cerif-orgunit.xsl`**
* `<Naam>` changed to `<Name>`, according to the specs

**Change in `cerif-project.xsl`**
* wrap the `<OrgUnit>` coming from `input:penvoerder` in a `<Coordinator>`
* wrap the `<OrgUnit>` coming from `input:samenwerking` in a `<Partner>`
* wrap the `<OrgUnit>` coming from `input:opdrachtgever` in a `<Member>`

For these three, could you verify that these are the correct wrappers? See [subclasses of `Consortium` in the specs](https://openaire-guidelines-for-cris-managers.readthedocs.io/en/latest/cerif_xml_project_entity.html#consortium): `Coordinator`, `Partner`, `Contractor` and `InKindContributor`. If you want me to use different wrappers for these, please let me know!

@wilkos-dans @DANS-KNAW/narcis for review