### PR TITLE
add DAI identifier to person CERIF OAI

### DIFF
--- a/meresco/xslt/cerif-person.xsl
+++ b/meresco/xslt/cerif-person.xsl
@@ -31,6 +31,7 @@
         <xsl:apply-templates select="input:nameIdentifier[@type='rid'][1]"/>
         <xsl:apply-templates select="input:nameIdentifier[@type='said'][1]"/>
         <xsl:apply-templates select="input:nameIdentifier[@type='isni'][1]"/>
+        <xsl:apply-templates select="input:nameIdentifier[@type='dai-nl'][1]"/>
 
         <xsl:apply-templates select="input:person_url"/>
 
@@ -106,6 +107,13 @@
             <xsl:text> </xsl:text>
             <xsl:value-of select="normalize-space($isni4)"/>
         </ISNI>
+    </xsl:template>
+
+    <xsl:template match="input:nameIdentifier[@type='dai-nl']">
+        <DAI>
+            <xsl:text>info:eu-repo/dai/nl/</xsl:text>
+            <xsl:value-of select="."/>
+        </DAI>
     </xsl:template>
 
     <xsl:template match="input:nameIdentifier[@type='rid']">


### PR DESCRIPTION
Adds the `dai-nl` name identifier transformation to the person CERIF OAI. This new identifier was introduced in https://github.com/openaire/guidelines-cris-managers/pull/49.

Given an input like `<nameIdentifier type="dai-nl">123456789</nameIdentifier>`, this should result in `<DAI>info:eu-repo/dai/nl/123456789</DAI>`.

@wilkos-dans can you check this is correct? Please update `tnarcis` with this change, such that we can run the validator on it.