### PR TITLE
#1165 Related identifiers and alternative identifiers from DC into knaw_long

### DIFF
--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -4,7 +4,6 @@
 ## end license ##
 
 import sys
-import urllib
 
 from lxml import etree
 from lxml.etree import parse, _ElementTree, tostring

--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -540,6 +540,8 @@ class NormaliseOaiRecord(UiaConverter):
                     attrib_dict['relationType'] = "References"
                     if str(identifier).find("semantics/dataset/") >= 0:
                         attrib_dict['resourceTypeGeneral'] = "dataset"
+                    elif str(identifier).find("semantics/reference/") >= 0:
+                        attrib_dict['resourceTypeGeneral'] = "publication"
                     etree.SubElement(e_longmetadata, "related_identifier", attrib_dict).text = pId.get_unformatted_id()
 
     def _getObjectFiles(self, lxmlNode, e_longRoot):
@@ -750,7 +752,6 @@ class NormaliseOaiRecord(UiaConverter):
                 etree.SubElement(e_name_type, 'mcRoleTerm').text = 'aut'
 
             # if dc.type == dissertation or doctoral thesis: marcrelator will be thesis advisor(ths) ctb (contributor) otherwise:
-            # xpath is case sensitive: just in case...
             dc_type_thesis_dissertation = lxmlNode.xpath('//dc:type[contains(.,"issertation") or contains(.,"thesis")]', namespaces=namespacesmap)
             dc_type_e = 'ctb'
             if dc_type_thesis_dissertation: dc_type_e = 'ths'
@@ -1417,5 +1418,5 @@ class NormaliseOaiRecord(UiaConverter):
                 startIdentifier = "info:eu-repo/semantics/{0!s}/".format(idtype.lower())
                 if identifier.lower().startswith(startIdentifier):
                     id = identifier[len(startIdentifier):].split("/", 1)
-                    return (id[0], urllib.unquote(id[1])) if len(id) == 2 else (None, None)
+                    return (id[0], id[1]) if len(id) == 2 else (None, None)
         return None, None

--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -4,18 +4,15 @@
 ## end license ##
 
 import sys
+import urllib
 
 from lxml import etree
 from lxml.etree import parse, _ElementTree, tostring
 
 from StringIO import StringIO
-from xml.sax.saxutils import escape as escapeXml
-
-from meresco.core import Observable
-from meresco.components import lxmltostring
 from meresco.dans.metadataformats import MetadataFormat
 from meresco.dans.uiaconverter import UiaConverter
-from meresco.dans.nameidentifier import Orcid, Dai, Isni, Rid, NameIdentifierFactory
+from meresco.dans.nameidentifier import NameIdentifierFactory
 from meresco.dans.persistentidentifier import PidFactory
 from meresco.xml import namespaces
 
@@ -23,8 +20,6 @@ from re import compile
 
 from dateutil.parser import parse as parseDate
 from datetime import *
-
-import time
 
 namespacesmap = namespaces.copyUpdate({ #  See: https://github.com/seecr/meresco-xml/blob/master/meresco/xml/namespaces.py
     
@@ -493,10 +488,10 @@ class NormaliseOaiRecord(UiaConverter):
 
 
     def _getRelatedIdentifiers(self, lxmlNode, e_longmetadata):
-        attrib_dict = {}
         if self._metadataformat.isDatacite():
             identifiers = lxmlNode.xpath("//datacite:resource/datacite:relatedIdentifiers/datacite:relatedIdentifier", namespaces=namespacesmap)
             for identifier in identifiers:
+                attrib_dict = {}
                 id_type = identifier.xpath('self::datacite:relatedIdentifier/@relatedIdentifierType', namespaces=namespacesmap)
                 idee = identifier.xpath('self::datacite:relatedIdentifier/text()', namespaces=namespacesmap)
                 if len(idee) > 0 and len(id_type) > 0: #create new element: <related_identifier type="doi" relationType="IsReferencedBy">doi:10.1006/jmbi.1995.0238</related_identifier>   
@@ -514,6 +509,7 @@ class NormaliseOaiRecord(UiaConverter):
         elif self._metadataformat.isMods():
             rel_items = lxmlNode.xpath("//mods:mods/mods:relatedItem", namespaces=namespacesmap)
             for item in rel_items:
+                attrib_dict = {}
                 item_href = item.xpath('self::mods:relatedItem/@xlink:href', namespaces=namespacesmap) # Get href from relatedItem
                 item_reltype = item.xpath('self::mods:relatedItem/@type', namespaces=namespacesmap)
                 if len(item_reltype) > 0: attrib_dict['relationType'] = item_reltype[0]
@@ -532,7 +528,19 @@ class NormaliseOaiRecord(UiaConverter):
                         attrib_dict['type'] = relId.get_name()
                         attrib_dict['idx'] = relId.get_idx_id()
                         etree.SubElement(e_longmetadata, "related_identifier", attrib_dict).text = relId.get_unformatted_id()
-
+        elif self._metadataformat.isDC():
+            identifierList = lxmlNode.xpath("//dc:relation/text()", namespaces=namespacesmap)
+            for identifier in identifierList:
+                attrib_dict = {}
+                pidtype, pidvalue = self._getOpenAIREIdentifierFromDcRelation(identifier, "reference|dataset")
+                pId = PidFactory.factory(pidtype, pidvalue)
+                if pId.is_valid():
+                    attrib_dict['type'] = pId.get_name()
+                    attrib_dict['idx'] = pId.get_idx_id()
+                    attrib_dict['relationType'] = "References"
+                    if str(identifier).find("semantics/dataset/") >= 0:
+                        attrib_dict['resourceTypeGeneral'] = "dataset"
+                    etree.SubElement(e_longmetadata, "related_identifier", attrib_dict).text = pId.get_unformatted_id()
 
     def _getObjectFiles(self, lxmlNode, e_longRoot):
         e_objectFiles = None
@@ -655,24 +663,11 @@ class NormaliseOaiRecord(UiaConverter):
                             blnHasValidRight = True
                             break
                     if blnHasValidRight: break
-            
+
         etree.SubElement(e_longRoot, "accessRights").text = accessRight # default 'openAccess'
 
     def _getNames(self, lxmlNode, e_longmetadata, root='//mods:mods/'):
-#MODS:
-# <name type="personal" ID="n1">
-#     <namePart type="family">Vries, de</namePart>
-#     <namePart type="given">J. (Jan)</namePart>
-#     <role>
-#         <roleTerm authority="marcrelator" type="code">aut</roleTerm>
-#     </role>
-#     <nameIdentifier type="dai-nl" typeURI="info:eu-repo/dai/nl">123456789</nameIdentifier>
-#     <nameIdentifier type="isni" typeURI="http://id.loc.gov/vocabulary/identifiers/isni">http://www.isni.org/0000000133334444555X</nameIdentifier>
-#     <nameIdentifier type="orcid" typeURI="http://id.loc.gov/vocabulary/identifiers/orcid">http://orcid.org/0000-0002-1825-0097</nameIdentifier>
-# </name>
 
-#knaw_long:
-# <dai>info:eu-repo/dai/nl/328277916</dai><nameIdentifier type=\"dai-nl\">328277916</nameIdentifier><nameIdentifier type=\"orcid\">000000021694233X</nameIdentifier><nameIdentifier type=\"isni\">0000000117247366</nameIdentifier>
         if self._metadataformat.isMods():
             nameTypes = ['personal','corporate','conference','NOTYPE'] # NOTYPE used to catch names without a type attribute! We will tread them as type 'personal'.
             namepartTypes=['family','given','termsOfAddress'] # 'unstructured' is special :(
@@ -745,7 +740,6 @@ class NormaliseOaiRecord(UiaConverter):
                         e_nid.attrib['type'] = supportedNids[0]
                         e_nid.text = dai
 
-
         # Get creators and contributors from DC if NO FULLMODS available, or if MMODS did not yield any authors:
         elif self._metadataformat.isDC():
             dc_creators = lxmlNode.xpath('//dc:creator/text()', namespaces=namespacesmap)
@@ -756,6 +750,7 @@ class NormaliseOaiRecord(UiaConverter):
                 etree.SubElement(e_name_type, 'mcRoleTerm').text = 'aut'
 
             # if dc.type == dissertation or doctoral thesis: marcrelator will be thesis advisor(ths) ctb (contributor) otherwise:
+            # xpath is case sensitive: just in case...
             dc_type_thesis_dissertation = lxmlNode.xpath('//dc:type[contains(.,"issertation") or contains(.,"thesis")]', namespaces=namespacesmap)
             dc_type_e = 'ctb'
             if dc_type_thesis_dissertation: dc_type_e = 'ths'
@@ -1076,6 +1071,14 @@ class NormaliseOaiRecord(UiaConverter):
                     hrefId = PidFactory.factory('href', hsp[0])
                     if hrefId.is_valid(): # Type 'href/url' gevonden...
                         etree.SubElement(e_longmetadata, "publication_identifier", type=hrefId.get_name(), idx=hrefId.get_idx_id()).text = hrefId.get_unformatted_id()
+
+        elif self._metadataformat.isDC():
+            identifierList = lxmlNode.xpath("//dc:relation/text()", namespaces=namespacesmap)
+            for identifier in identifierList:
+                pidtype, pidvalue = self._getOpenAIREIdentifierFromDcRelation(identifier, "altIdentifier")
+                pId = PidFactory.factory(pidtype, pidvalue)
+                if pId.is_valid():
+                    etree.SubElement(e_longmetadata, "publication_identifier", type=pId.get_name(), idx=pId.get_idx_id()).text = pId.get_unformatted_id()
 
 
     def _getLanguage(self, lxmlNode, e_longmetadata):
@@ -1407,3 +1410,12 @@ class NormaliseOaiRecord(UiaConverter):
             return str(di_1.date().year) # Only year has been parsed succesfully.
         if di_1.date().day != di_2.date().day and di_1.date().month == di_2.date().month:
             return ('%s-%s') % (di_1.date().year, di_1.date().month) # Only year and month have been parsed succesfully.
+
+    def _getOpenAIREIdentifierFromDcRelation(self, identifier, idtypes):
+        if identifier is not None and idtypes is not None:
+            for idtype in idtypes.split("|"):
+                startIdentifier = "info:eu-repo/semantics/{0!s}/".format(idtype.lower())
+                if identifier.lower().startswith(startIdentifier):
+                    id = identifier[len(startIdentifier):].split("/", 1)
+                    return (id[0], urllib.unquote(id[1])) if len(id) == 2 else (None, None)
+        return None, None

--- a/meresco/dans/persistentidentifier/doi.py
+++ b/meresco/dans/persistentidentifier/doi.py
@@ -5,7 +5,7 @@ from persistentidentifier import PersistentIdentifier
 
 
 class Doi(PersistentIdentifier):
-    DOIURI_PATTERN = compile("^https?://(dx\\.)?doi\\.org/(urn:)?(doi:)?", IGNORECASE)
+    DOIURI_PATTERN = compile("^(https?://(dx\\.)?)?doi\\.org/(urn:)?(doi:)?", IGNORECASE)
     ID_PATTERN = compile("^(?:urn:)?(?:doi:)?(10(?:\\.[0-9]+)+)/(.+)$", IGNORECASE)
 
     def __init__(self, baseDigits):

--- a/test/_integration/apitest.py
+++ b/test/_integration/apitest.py
@@ -223,6 +223,10 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('en', testNamespaces.xpathFirst(response, '//long:metadata/long:language/text()'))
         self.assertEqual(1, len(testNamespaces.xpath(response, '//long:metadata/long:name')))
         self.assertEqual(1, len(testNamespaces.xpath(response, '//long:metadata/long:subject/long:topic')))
+        self.assertEqual(2, len(testNamespaces.xpath(response, '//long:metadata/long:publication_identifier')))
+        self.assertEqual('10.1002/lno.10611', testNamespaces.xpathFirst(response, '//long:metadata/long:publication_identifier/text()'))
+        self.assertEqual(2, len(testNamespaces.xpath(response, '//long:metadata/long:related_identifier')))
+        self.assertEqual('10.1234.567/abc', testNamespaces.xpathFirst(response, '//long:metadata/long:related_identifier/text()'))
 
     def testDidlDcToLong(self):
         response = self.doSruQuery(**{'query': '2016-01-31', 'recordSchema':'knaw_long'})

--- a/test/data/0010_dc_pub_meresco_record_1.updateRequest
+++ b/test/data/0010_dc_pub_meresco_record_1.updateRequest
@@ -20,6 +20,10 @@
             &lt;dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;Search&lt;/dc:subject&gt;
             &lt;dc:language xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;en&lt;/dc:language&gt;
             &lt;dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;restrictedAccess&lt;/dc:rights&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/doi/doi.org%2F10.1002%2Flno.10611&lt;/dc:relation&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/wos/000423029300003&lt;/dc:relation&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/dataset/doi/10.1234.567/abc&lt;/dc:relation&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/reference/urn/urn:nbn:nl:ui:19-4567890&lt;/dc:relation&gt;
             &lt;/oai_dc:dc&gt;&lt;/metadata&gt;
             &lt;/record&gt;</part>
             <part name="meta">&lt;meta xmlns=&quot;http://meresco.org/namespace/harvester/meta&quot;&gt;

--- a/test/data/0010_dc_pub_meresco_record_1.updateRequest
+++ b/test/data/0010_dc_pub_meresco_record_1.updateRequest
@@ -20,7 +20,7 @@
             &lt;dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;Search&lt;/dc:subject&gt;
             &lt;dc:language xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;en&lt;/dc:language&gt;
             &lt;dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;restrictedAccess&lt;/dc:rights&gt;
-            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/doi/doi.org%2F10.1002%2Flno.10611&lt;/dc:relation&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/doi/doi.org/10.1002/lno.10611&lt;/dc:relation&gt;
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/wos/000423029300003&lt;/dc:relation&gt;
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/dataset/doi/10.1234.567/abc&lt;/dc:relation&gt;
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/reference/urn/urn:nbn:nl:ui:19-4567890&lt;/dc:relation&gt;


### PR DESCRIPTION
Adds `publication identifiers` and `related identifiers` from DC (`<dc:relation>`) into knaw_long
- publication identifiers: `info:eu-repo/semantics/altIdentifier`
- related identifiers `info:eu-repo/semantics/reference` | `info:eu-repo/semantics/dataset`