### PR TITLE
Narcis-meresco #1243: Software as dataset-type

### DIFF
--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -874,7 +874,7 @@ class NormaliseOaiRecord(UiaConverter):
         elif self._metadataformat.isDatacite(): # DataCite is all about researchdata/datasets...
             if self._wcpcollection in ['dataset']:
                 genre = lxmlNode.xpath('//datacite:resource/datacite:resourceType/@resourceTypeGeneral', namespaces=namespacesmap)
-                if len(genre) > 0 and genre[0].lower().strip() in [dctype.lower() for dctype in datacite_datasetGenres]:
+                if len(genre) > 0 and genre[0].lower().strip() in [dc_genre.lower() for dc_genre in datacite_datasetGenres]:
                     etree.SubElement(e_longmetadata, "genre").text = genre[0].lower().strip()
                 else:
                     etree.SubElement(e_longmetadata, "genre").text = 'dataset'

--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -870,7 +870,11 @@ class NormaliseOaiRecord(UiaConverter):
                 etree.SubElement(e_longmetadata, "genre").text = self._getLabelFromGenreURI(modsGenre[0])
         elif self._metadataformat.isDatacite(): # DataCite is all about researchdata/datasets...
             if self._wcpcollection in ['dataset']:
-                etree.SubElement(e_longmetadata, "genre").text = 'dataset'
+                genre = lxmlNode.xpath('//datacite:resource/datacite:resourceType/@resourceTypeGeneral', namespaces=namespacesmap)
+                if len(genre) > 0 and genre[0].lower().strip() in [dctype.lower() for dctype in datacite_resourceTypeGeneral]:
+                    etree.SubElement(e_longmetadata, "genre").text = genre[0]
+                else:
+                    etree.SubElement(e_longmetadata, "genre").text = 'dataset'
             else: # Get 'genre' from metadata:
                 genre = lxmlNode.xpath('//datacite:resource/datacite:resourceType/text()', namespaces=namespacesmap)
                 if len(genre) > 0 and self._getLabelFromGenreURI(genre[0]) in pubTypes:

--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -872,7 +872,7 @@ class NormaliseOaiRecord(UiaConverter):
             if self._wcpcollection in ['dataset']:
                 genre = lxmlNode.xpath('//datacite:resource/datacite:resourceType/@resourceTypeGeneral', namespaces=namespacesmap)
                 if len(genre) > 0 and genre[0].lower().strip() in [dctype.lower() for dctype in datacite_resourceTypeGeneral]:
-                    etree.SubElement(e_longmetadata, "genre").text = genre[0]
+                    etree.SubElement(e_longmetadata, "genre").text = genre[0].lower().strip()
                 else:
                     etree.SubElement(e_longmetadata, "genre").text = 'dataset'
             else: # Get 'genre' from metadata:

--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -91,6 +91,9 @@ datacite_resourceTypeGeneral = ['Audiovisual','Collection','Dataset','Event','Im
 # DATACITE Controlled List Description Types:
 datacite_descriptionTypes = ['Abstract','Other','TableOfContents','SeriesInformation','TechnicalInfo','Methods']
 
+# DATACITE Dataset Genre Values:
+datacite_datasetGenres = ['Dataset','Software']
+
 # mods:nameIdentifiers that will be processed to long. Other types will be ignored.
 # ORDER does matter!
 supportedNids = ['dai-nl', 'orcid', 'isni', 'nod-prs']
@@ -871,7 +874,7 @@ class NormaliseOaiRecord(UiaConverter):
         elif self._metadataformat.isDatacite(): # DataCite is all about researchdata/datasets...
             if self._wcpcollection in ['dataset']:
                 genre = lxmlNode.xpath('//datacite:resource/datacite:resourceType/@resourceTypeGeneral', namespaces=namespacesmap)
-                if len(genre) > 0 and genre[0].lower().strip() in [dctype.lower() for dctype in datacite_resourceTypeGeneral]:
+                if len(genre) > 0 and genre[0].lower().strip() in [dctype.lower() for dctype in datacite_datasetGenres]:
                     etree.SubElement(e_longmetadata, "genre").text = genre[0].lower().strip()
                 else:
                     etree.SubElement(e_longmetadata, "genre").text = 'dataset'

--- a/test/_alltests.py
+++ b/test/_alltests.py
@@ -47,6 +47,8 @@ from nameidentifiertest import NameIdentifierTest
 # Converters:
 from convertertest import ConverterTest
 from metapartconvertertest import MetaPartConverterTest
+from long_converter_genre_test import LongConverterGenreTest
+from long_converter_access_rights_test import LongConverterAccessRightsTest
 
 
 if __name__ == '__main__':

--- a/test/_integration/apitest.py
+++ b/test/_integration/apitest.py
@@ -376,6 +376,8 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('2009-11-24', testNamespaces.xpathFirst(response, '//long:metadata/long:dateAvailable/long:parsed/text()'))
         self.assertEqual('urn:nbn:nl:ui:13-jsk-7ek', testNamespaces.xpathFirst(response, '//long:metadata/long:publication_identifier[@type="nbn"]/text()'))
         self.assertEqual('dataset', testNamespaces.xpathFirst(response, '//long:metadata/long:typeOfResource/@generaltype'))
+        self.assertEqual('Dataset/Dataset en zo', testNamespaces.xpathFirst(response, '//long:metadata/long:typeOfResource/text()'))
+        self.assertEqual('dataset', testNamespaces.xpathFirst(response, '//long:metadata/long:genre/text()'))
         self.assertEqual('European Commission', testNamespaces.xpathFirst(response, '//long:metadata/long:grantAgreements//long:grantAgreement/long:funder/text()'))
         self.assertEqual('nl', testNamespaces.xpathFirst(response, '//long:metadata/long:language/text()'))
         self.assertEqual('19 p.', testNamespaces.xpathFirst(response, '//long:metadata/long:format/text()'))

--- a/test/long_converter_access_rights_test.py
+++ b/test/long_converter_access_rights_test.py
@@ -1,0 +1,105 @@
+# encoding=utf-8
+## begin license ##
+# 
+# "Meresco Components" are components to build searchengines, repositories
+# and archives, based on "Meresco Core". 
+# 
+# Copyright (C) 2012 Seecr (Seek You Too B.V.) http://seecr.nl
+# 
+# This file is part of "Meresco Components"
+# 
+# "Meresco Components" is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# "Meresco Components" is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with "Meresco Components"; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# 
+## end license ##
+
+from meresco.dans.metadataformats import MetadataFormat
+from lxml import etree
+from test.long_converter_test import LongConverterTest, baseXmls, long, namespacesmap, Format, Item
+
+ELEMENT_VALUE = 'element_value'
+ATTRIBUTE_VALUE = 'attribute_value'
+EXPECTED = 'expected'
+MODS_3 = 'mods_3'
+ACCESS_LEVELS = ['openAccess', 'restrictedAccess', 'closedAccess', 'embargoedAccess']
+
+test_items = {Format.OAI_DC:   [{ELEMENT_VALUE: 'openAccess', EXPECTED: 'openAccess'},
+                                {ELEMENT_VALUE: 'restrictedAccess', EXPECTED: 'restrictedAccess'},
+                                {ELEMENT_VALUE: 'closedAccess', EXPECTED: 'closedAccess'},
+                                {ELEMENT_VALUE: 'embargoedAccess', EXPECTED: 'embargoedAccess'},
+                                {ELEMENT_VALUE: 'something', EXPECTED: 'openAccess'}],
+              Format.DATACITE: [{ELEMENT_VALUE: 'info:eu-repo/semantics/openAccess', EXPECTED: 'openAccess'},
+                                {ELEMENT_VALUE: 'info:eu-repo/semantics/restrictedAccess', EXPECTED: 'restrictedAccess'},
+                                {ELEMENT_VALUE: 'closedAccess', EXPECTED: 'closedAccess'},
+                                {ELEMENT_VALUE: 'embargoedAccess', EXPECTED: 'embargoedAccess'},
+                                {ELEMENT_VALUE: 'something else', EXPECTED: 'openAccess'}],
+              MODS_3:          [{ELEMENT_VALUE: 'text...', ATTRIBUTE_VALUE: 'info:eu-repo/semantics/openAccess', EXPECTED: 'openAccess'},
+                                {ELEMENT_VALUE: 'text...', ATTRIBUTE_VALUE: 'info:eu-repo/semantics/restrictedAccess', EXPECTED: 'restrictedAccess'},
+                                {ELEMENT_VALUE: 'text...', ATTRIBUTE_VALUE: 'info:eu-repo/semantics/closedAccess', EXPECTED: 'closedAccess'},
+                                {ELEMENT_VALUE: 'text...', ATTRIBUTE_VALUE: 'embargoedAccess', EXPECTED: 'embargoedAccess'},
+                                {ELEMENT_VALUE: 'text...', ATTRIBUTE_VALUE: 'something', EXPECTED: 'openAccess'}]
+              }
+
+
+class LongConverterAccessRightsTest(LongConverterTest):
+
+    def test_access_rights(self):
+        print "\nRunning LongConverter Access Rights test",
+        for format in Format:
+            xml = etree.fromstring(baseXmls[format])
+            self._test(format, xml)
+        print ""
+
+    def _test(self, format, xml):
+
+        long._metadataformat = MetadataFormat(xml, long._uploadid)
+        if format == Format.OAI_DC:
+            self._test_oai_dc(format, xml)
+        elif format == Format.DATACITE:
+            self._test_datacite(format, xml)
+        elif long._metadataformat.isMods3():
+            self._test_mods(MODS_3, xml)
+
+    # OAI_DC
+    def _test_oai_dc(self, format, xml):
+
+        dc = "http://purl.org/dc/elements/1.1/"
+        rights = '{' + dc + '}' + 'rights'
+
+        for t in test_items[format]:
+            self._reset(xml)
+            self._addElement(self.xml, rights, t[ELEMENT_VALUE])
+            self._assert(Item.ACCESS_RIGHTS, t[EXPECTED])
+
+    # MODS 3
+    def _test_mods(self, format, xml):
+
+        mods = "http://www.loc.gov/mods/v3"
+        access_condition = '{' + mods + '}' + 'accessCondition'
+
+        for t in test_items[format]:
+            self._reset(xml)
+            mods = self.xml.find(".//mods:mods", namespaces=namespacesmap)
+            self._addElement(mods, access_condition, t[ELEMENT_VALUE], 'type', t[ATTRIBUTE_VALUE])
+            self._assert(Item.ACCESS_RIGHTS, t[EXPECTED])
+
+    # DATACITE
+    def _test_datacite(self, format, xml):
+
+        for t in test_items[format]:
+            self._reset(xml)
+            resource = self.xml.find(".//datacite:resource", namespaces=namespacesmap)
+            rights_list_element = self._addElement(resource, 'rightsList')
+            self._addElement(rights_list_element, 'rights', t[ELEMENT_VALUE])
+            self._assert(Item.ACCESS_RIGHTS, t[EXPECTED])

--- a/test/long_converter_genre_test.py
+++ b/test/long_converter_genre_test.py
@@ -1,0 +1,73 @@
+# encoding=utf-8
+## begin license ##
+# 
+# "Meresco Components" are components to build searchengines, repositories
+# and archives, based on "Meresco Core". 
+# 
+# Copyright (C) 2012 Seecr (Seek You Too B.V.) http://seecr.nl
+# 
+# This file is part of "Meresco Components"
+# 
+# "Meresco Components" is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# "Meresco Components" is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with "Meresco Components"; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# 
+## end license ##
+
+from meresco.dans.metadataformats import MetadataFormat
+from lxml import etree
+from test.long_converter_test import LongConverterTest, baseXmls, long, namespacesmap, Format, Item
+
+ELEMENT_VALUE = 'element_value'
+ATTRIBUTE_VALUE = 'attribute_value'
+EXPECTED = 'expected'
+
+test_items = {Format.OAI_DC:   [{ELEMENT_VALUE: 'newspaper', EXPECTED: 'contributiontoperiodical'},
+                                {ELEMENT_VALUE: 'bookpart', EXPECTED: 'bookpart'}],
+              Format.DATACITE: [{ELEMENT_VALUE: 'Dataset about software', ATTRIBUTE_VALUE: 'Software', EXPECTED: 'software'},
+                                {ELEMENT_VALUE: 'Dataset...', ATTRIBUTE_VALUE: '', EXPECTED: 'dataset'},
+                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', EXPECTED: 'dataset'}]
+              }
+
+class LongConverterGenreTest(LongConverterTest):
+
+    def test_genre(self):
+        for format in Format:
+            xml = etree.fromstring(baseXmls[format])
+            self._test(format, xml)
+
+    def _test(self, format, xmlBase):
+
+        long._metadataformat = MetadataFormat(xmlBase, long._uploadid)
+        long._wcpcollection = 'dataset'
+        getattr(self, '_test_' + format.value)(format, xmlBase)
+
+    # OAI_DC
+    def _test_oai_dc(self, format, xmlBase):
+
+        dc = "http://purl.org/dc/elements/1.1/"
+        type = '{' + dc + '}' + 'type'
+
+        for t in test_items[format]:
+            self._reset(xmlBase)
+            self._addElement(self.xml, type, t[ELEMENT_VALUE])
+            self._assert(Item.GENRE, t[EXPECTED])
+
+    # DATACITE
+    def _test_datacite(self, format, xmlBase):
+
+        for t in test_items[format]:
+            self._reset(xmlBase)
+            resource = self.xml.find("datacite:resource", namespaces=namespacesmap)
+            self._addElement(resource, 'resourceType', t[ELEMENT_VALUE], 'resourceTypeGeneral', t[ATTRIBUTE_VALUE])
+            self._assert(Item.GENRE, t[EXPECTED])

--- a/test/long_converter_genre_test.py
+++ b/test/long_converter_genre_test.py
@@ -31,43 +31,70 @@ from test.long_converter_test import LongConverterTest, baseXmls, long, namespac
 ELEMENT_VALUE = 'element_value'
 ATTRIBUTE_VALUE = 'attribute_value'
 EXPECTED = 'expected'
+MODS = 'mods'
 
 test_items = {Format.OAI_DC:   [{ELEMENT_VALUE: 'newspaper', EXPECTED: 'contributiontoperiodical'},
                                 {ELEMENT_VALUE: 'bookpart', EXPECTED: 'bookpart'}],
               Format.DATACITE: [{ELEMENT_VALUE: 'Dataset about software', ATTRIBUTE_VALUE: 'Software', EXPECTED: 'software'},
                                 {ELEMENT_VALUE: 'Dataset...', ATTRIBUTE_VALUE: '', EXPECTED: 'dataset'},
-                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', EXPECTED: 'dataset'}]
+                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', EXPECTED: 'dataset'},
+                                {ELEMENT_VALUE: 'Other collection', ATTRIBUTE_VALUE: '', EXPECTED: 'other collection'}],
+              MODS:             [{ELEMENT_VALUE: 'info:eu-repo/semantics/article', EXPECTED: 'article'},
+                                {ELEMENT_VALUE: 'info:eu-repo/semantics/something', EXPECTED: None}]
               }
+
 
 class LongConverterGenreTest(LongConverterTest):
 
     def test_genre(self):
+        print "\nRunning LongConverter Genre test",
         for format in Format:
             xml = etree.fromstring(baseXmls[format])
             self._test(format, xml)
+        print ""
 
-    def _test(self, format, xmlBase):
+    def _test(self, format, xml):
 
-        long._metadataformat = MetadataFormat(xmlBase, long._uploadid)
-        long._wcpcollection = 'dataset'
-        getattr(self, '_test_' + format.value)(format, xmlBase)
+        long._metadataformat = MetadataFormat(xml, long._uploadid)
+        if format == Format.OAI_DC:
+            self._test_oai_dc(format, xml)
+        elif format == Format.DATACITE:
+            self._test_datacite(format, xml)
+        elif long._metadataformat.isMods():
+            self._test_mods(MODS, xml)
 
     # OAI_DC
-    def _test_oai_dc(self, format, xmlBase):
+    def _test_oai_dc(self, format, xml):
 
         dc = "http://purl.org/dc/elements/1.1/"
         type = '{' + dc + '}' + 'type'
 
         for t in test_items[format]:
-            self._reset(xmlBase)
+            self._reset(xml)
             self._addElement(self.xml, type, t[ELEMENT_VALUE])
             self._assert(Item.GENRE, t[EXPECTED])
 
-    # DATACITE
-    def _test_datacite(self, format, xmlBase):
+    # MODS
+    def _test_mods(self, format, xml):
+
+        mods = "http://www.loc.gov/mods/v3"
+        genre = '{' + mods + '}' + 'genre'
 
         for t in test_items[format]:
-            self._reset(xmlBase)
-            resource = self.xml.find("datacite:resource", namespaces=namespacesmap)
+            self._reset(xml)
+            mods = self.xml.find(".//mods:mods", namespaces=namespacesmap)
+            self._addElement(mods, genre, t[ELEMENT_VALUE])
+            self._assert(Item.GENRE, t[EXPECTED])
+
+    # DATACITE
+    def _test_datacite(self, format, xml):
+
+        for t in test_items[format]:
+            if t[ELEMENT_VALUE] == 'Other collection':
+                long._wcpcollection = ''
+            else:
+                long._wcpcollection = 'dataset'
+            self._reset(xml)
+            resource = self.xml.find(".//datacite:resource", namespaces=namespacesmap)
             self._addElement(resource, 'resourceType', t[ELEMENT_VALUE], 'resourceTypeGeneral', t[ATTRIBUTE_VALUE])
             self._assert(Item.GENRE, t[EXPECTED])

--- a/test/long_converter_genre_test.py
+++ b/test/long_converter_genre_test.py
@@ -31,14 +31,16 @@ from test.long_converter_test import LongConverterTest, baseXmls, long, namespac
 ELEMENT_VALUE = 'element_value'
 ATTRIBUTE_VALUE = 'attribute_value'
 EXPECTED = 'expected'
+COLLECTION = 'collection'
 MODS = 'mods'
 
 test_items = {Format.OAI_DC:   [{ELEMENT_VALUE: 'newspaper', EXPECTED: 'contributiontoperiodical'},
                                 {ELEMENT_VALUE: 'bookpart', EXPECTED: 'bookpart'}],
-              Format.DATACITE: [{ELEMENT_VALUE: 'Dataset about software', ATTRIBUTE_VALUE: 'Software', EXPECTED: 'software'},
-                                {ELEMENT_VALUE: 'Dataset...', ATTRIBUTE_VALUE: '', EXPECTED: 'dataset'},
-                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', EXPECTED: 'dataset'},
-                                {ELEMENT_VALUE: 'Other collection', ATTRIBUTE_VALUE: '', EXPECTED: 'other collection'}],
+              Format.DATACITE: [{ELEMENT_VALUE: 'Dataset about software', ATTRIBUTE_VALUE: 'Software', COLLECTION: 'dataset', EXPECTED: 'software'},
+                                {ELEMENT_VALUE: 'Dataset...', ATTRIBUTE_VALUE: '', COLLECTION: 'dataset', EXPECTED: 'dataset'},
+                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', COLLECTION: 'dataset', EXPECTED: 'dataset'},
+                                {ELEMENT_VALUE: 'article', ATTRIBUTE_VALUE: '', COLLECTION: 'other', EXPECTED: 'article'},
+                                {ELEMENT_VALUE: 'something else', ATTRIBUTE_VALUE: '', COLLECTION: 'other', EXPECTED: None}],
               MODS:             [{ELEMENT_VALUE: 'info:eu-repo/semantics/article', EXPECTED: 'article'},
                                 {ELEMENT_VALUE: 'info:eu-repo/semantics/something', EXPECTED: None}]
               }
@@ -90,10 +92,7 @@ class LongConverterGenreTest(LongConverterTest):
     def _test_datacite(self, format, xml):
 
         for t in test_items[format]:
-            if t[ELEMENT_VALUE] == 'Other collection':
-                long._wcpcollection = ''
-            else:
-                long._wcpcollection = 'dataset'
+            long._wcpcollection = t[COLLECTION]
             self._reset(xml)
             resource = self.xml.find(".//datacite:resource", namespaces=namespacesmap)
             self._addElement(resource, 'resourceType', t[ELEMENT_VALUE], 'resourceTypeGeneral', t[ATTRIBUTE_VALUE])

--- a/test/long_converter_genre_test.py
+++ b/test/long_converter_genre_test.py
@@ -38,7 +38,7 @@ test_items = {Format.OAI_DC:   [{ELEMENT_VALUE: 'newspaper', EXPECTED: 'contribu
                                 {ELEMENT_VALUE: 'bookpart', EXPECTED: 'bookpart'}],
               Format.DATACITE: [{ELEMENT_VALUE: 'Dataset about software', ATTRIBUTE_VALUE: 'Software', COLLECTION: 'dataset', EXPECTED: 'software'},
                                 {ELEMENT_VALUE: 'Dataset...', ATTRIBUTE_VALUE: '', COLLECTION: 'dataset', EXPECTED: 'dataset'},
-                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'just something', COLLECTION: 'dataset', EXPECTED: 'dataset'},
+                                {ELEMENT_VALUE: 'something', ATTRIBUTE_VALUE: 'Collection', COLLECTION: 'dataset', EXPECTED: 'dataset'},
                                 {ELEMENT_VALUE: 'article', ATTRIBUTE_VALUE: '', COLLECTION: 'other', EXPECTED: 'article'},
                                 {ELEMENT_VALUE: 'something else', ATTRIBUTE_VALUE: '', COLLECTION: 'other', EXPECTED: None}],
               MODS:             [{ELEMENT_VALUE: 'info:eu-repo/semantics/article', EXPECTED: 'article'},

--- a/test/long_converter_test.py
+++ b/test/long_converter_test.py
@@ -1,0 +1,86 @@
+# encoding=utf-8
+## begin license ##
+# 
+# "Meresco Components" are components to build searchengines, repositories
+# and archives, based on "Meresco Core". 
+# 
+# Copyright (C) 2012 Seecr (Seek You Too B.V.) http://seecr.nl
+# 
+# This file is part of "Meresco Components"
+# 
+# "Meresco Components" is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# "Meresco Components" is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with "Meresco Components"; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# 
+## end license ##
+
+import copy
+import unittest
+from meresco.dans.longconverter import NormaliseOaiRecord
+from meresco.dans.uiaconverter import UiaConverter
+from lxml import etree
+from meresco.xml import namespaces
+from enum import Enum
+
+class Format(Enum):
+    OAI_DC = 'oai_dc'
+    DATACITE = 'datacite'
+
+class Item(Enum):
+    GENRE = 'genre'
+
+xmlOaiDc = '<root><oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"/></root>'
+xmlDatacite = '<root xmlns="http://datacite.org/schema/kernel-4"><resource/></root>'
+
+baseXmls = {Format.OAI_DC: xmlOaiDc, Format.DATACITE: xmlDatacite}
+methods = {Item.GENRE: '_getGenre'}
+
+testEmpty = etree.fromstring('<test/>')
+long = NormaliseOaiRecord(UiaConverter)
+
+namespacesmap = namespaces.copyUpdate(
+    {  # See: https://github.com/seecr/meresco-xml/blob/master/meresco/xml/namespaces.py
+        'dip': 'urn:mpeg:mpeg21:2005:01-DIP-NS',
+        'dii': 'urn:mpeg:mpeg21:2002:01-DII-NS',
+        'xlink': 'http://www.w3.org/1999/xlink',
+        'dai': 'info:eu-repo/dai',
+        'gal': 'info:eu-repo/grantAgreement',
+        'wmp': 'http://www.surfgroepen.nl/werkgroepmetadataplus',
+        'prs': 'http://www.onderzoekinformatie.nl/nod/prs',
+        'proj': 'http://www.onderzoekinformatie.nl/nod/act',
+        'org': 'http://www.onderzoekinformatie.nl/nod/org',
+        'long': 'http://www.knaw.nl/narcis/1.0/long/',
+        'short': 'http://www.knaw.nl/narcis/1.0/short/',
+        'mods': 'http://www.loc.gov/mods/v3',
+        'didl': 'urn:mpeg:mpeg21:2002:02-DIDL-NS',
+        'norm': 'http://dans.knaw.nl/narcis/normalized',
+        'datacite': 'http://datacite.org/schema/kernel-4'
+    })
+
+class LongConverterTest(unittest.TestCase):
+
+    def _reset(self, xmlBase):
+        self.xml = copy.deepcopy(xmlBase)
+        self.test = copy.deepcopy(testEmpty)
+
+    def _addElement(self, xml, element, elementValue, attribute=None, attributeValue=None):
+        e = etree.SubElement(xml, element)
+        e.text = elementValue
+        if attribute:
+            e.attrib[attribute] = attributeValue
+
+    def _assert(self, item, expected):
+        self.xml = etree.fromstring(etree.tostring(self.xml))
+        getattr(long, methods[item])(self.xml, self.test)
+        value = self.test.find(item.value).text
+        self.assertEqual(expected, value)

--- a/test/long_converter_test.py
+++ b/test/long_converter_test.py
@@ -93,7 +93,6 @@ class LongConverterTest(unittest.TestCase):
 
     def _assert(self, item, expected):
         self.xml = etree.fromstring(etree.tostring(self.xml))
-        # print(etree.tostring(self.xml))
         getattr(long, methods[item])(self.xml, self.test)
         if self.test.find(item.value) >= 0:
             value = self.test.find(item.value).text

--- a/test/long_converter_test.py
+++ b/test/long_converter_test.py
@@ -34,16 +34,26 @@ from enum import Enum
 
 class Format(Enum):
     OAI_DC = 'oai_dc'
+    DIDLM23 = 'didl_mods231'
+    DIDLM30 = 'didl_mods30'
+    DIDLM36 = 'didl_mods36'
+    DIDLDC = 'didl_dc'
     DATACITE = 'datacite'
+
 
 class Item(Enum):
     GENRE = 'genre'
+    ACCESS_RIGHTS = 'accessRights'
 
-xmlOaiDc = '<root><oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"/></root>'
-xmlDatacite = '<root xmlns="http://datacite.org/schema/kernel-4"><resource/></root>'
+xmlOaiDc =      '<root xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"><oai_dc:dc/></root>'
+xmlDidlMods23 = '<root xmlns:didl="urn:mpeg:mpeg21:2002:02-DIDL-NS" xmlns:mods="http://www.loc.gov/mods/v3"><didl:DIDL><mods:mods/></didl:DIDL></root>'
+xmlDidlMods30 = '<root xmlns:didl="urn:mpeg:mpeg21:2002:02-DIDL-NS" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"><didl:DIDL><mods:mods/><rdf:something/></didl:DIDL></root>'
+xmlDidlMods36 = '<root xmlns:mods="http://www.loc.gov/mods/v3"><mods:mods/></root>'
+xmlDidlDc =     '<root xmlns:didl="urn:mpeg:mpeg21:2002:02-DIDL-NS" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"><didl:DIDL><oai_dc:dc/></didl:DIDL></root>'
+xmlDatacite =   '<root xmlns="http://datacite.org/schema/kernel-4"><resource/></root>'
 
-baseXmls = {Format.OAI_DC: xmlOaiDc, Format.DATACITE: xmlDatacite}
-methods = {Item.GENRE: '_getGenre'}
+baseXmls = {Format.OAI_DC: xmlOaiDc, Format.DIDLM23: xmlDidlMods23, Format.DIDLM30: xmlDidlMods30, Format.DIDLM36: xmlDidlMods36, Format.DIDLDC: xmlDidlDc, Format.DATACITE: xmlDatacite}
+methods = {Item.GENRE: '_getGenre', Item.ACCESS_RIGHTS: '_getAccessRights'}
 
 testEmpty = etree.fromstring('<test/>')
 long = NormaliseOaiRecord(UiaConverter)
@@ -73,14 +83,21 @@ class LongConverterTest(unittest.TestCase):
         self.xml = copy.deepcopy(xmlBase)
         self.test = copy.deepcopy(testEmpty)
 
-    def _addElement(self, xml, element, elementValue, attribute=None, attributeValue=None):
+    def _addElement(self, xml, element, elementValue=None, attribute=None, attributeValue=None):
         e = etree.SubElement(xml, element)
-        e.text = elementValue
+        if elementValue:
+            e.text = elementValue
         if attribute:
             e.attrib[attribute] = attributeValue
+        return e
 
     def _assert(self, item, expected):
         self.xml = etree.fromstring(etree.tostring(self.xml))
+        # print(etree.tostring(self.xml))
         getattr(long, methods[item])(self.xml, self.test)
-        value = self.test.find(item.value).text
+        if self.test.find(item.value) >= 0:
+            value = self.test.find(item.value).text
+        else:
+            value = None
         self.assertEqual(expected, value)
+        print "+",


### PR DESCRIPTION
* for `Datacite` `genre` is the value of attribute `resourceTypeGeneral`  if it is found in the list `datacite_resourceTypeGeneral`. Otherwise the value is `"dataset"`.
* generic test methods added to unit test `knaw_long` elements
* added unit tests for element `genre`
* to verify the "genercity" of the test methods, added also unit tests for element `accessRights`