### PR TITLE
More CERIF XSLT (patent, product and publication)

### DIFF
--- a/meresco/xsd/knaw_long-1-1.xsd
+++ b/meresco/xsd/knaw_long-1-1.xsd
@@ -15,6 +15,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="0" ref="long:wcpcollection"/>
+        <xs:element ref="long:uploadid"/>
         <xs:element minOccurs="0" ref="long:modificationDate"/>
         <xs:element ref="long:humanStartPage"/>
         <xs:element minOccurs="0" ref="long:persistentIdentifier"/>
@@ -26,6 +27,7 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="wcpcollection" type="xs:NCName"/>
+  <xs:element name="uploadid" type="xs:string"/>
   <xs:element name="modificationDate" type="xs:string"/>
   <xs:element name="humanStartPage" type="xs:anyURI"/>
   <xs:element name="persistentIdentifier">
@@ -81,6 +83,7 @@
         <xs:group   minOccurs="0" maxOccurs="unbounded" ref="long:date"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:publication_identifier"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:related_identifier"/>
+        <xs:element ref="long:patent_number"/>
         <xs:element minOccurs="0" ref="long:language"/>        
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:location_url"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:relatedItem"/>
@@ -211,6 +214,7 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:element name="patent_number" type="xs:string"/>
   <xs:element name="language" type="xs:language"/>
   <xs:element name="location_url" type="xs:anyURI"/>
   <xs:element name="relatedItem">

--- a/meresco/xsd/knaw_long-1-1.xsd
+++ b/meresco/xsd/knaw_long-1-1.xsd
@@ -145,6 +145,7 @@
       <xs:enumeration value="orcid" />
       <xs:enumeration value="isni" />
       <xs:enumeration value="nod-prs" />
+      <xs:enumeration value="nod-org" />
     </xs:restriction>
   </xs:simpleType>
   <xs:element name="affiliation" type="xs:string"/>

--- a/meresco/xsd/knaw_long-1-1.xsd
+++ b/meresco/xsd/knaw_long-1-1.xsd
@@ -35,6 +35,7 @@
       <xs:simpleContent>
         <xs:extension base="xs:anyURI">
           <xs:attribute name="ref" type="xs:string"/>
+          <xs:attribute name="type" use="required" type="xs:NCName"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -94,6 +95,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:grantAgreements"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="long:geoLocations"/>
         <xs:element minOccurs="0" ref="long:hostCitation"/>
+        <xs:element minOccurs="0" ref="long:publicationYear"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -205,12 +207,23 @@
       <xs:element name="parsed" minOccurs="0" type="xs:NMTOKEN"/>
     </xs:all>
   </xs:complexType>
-  <xs:element name="publication_identifier" type="long:identifier"/>
-  <xs:element name="related_identifier" type="long:identifier"/>
-  <xs:complexType name="identifier">
+  <xs:element name="publication_identifier" type="long:publication_identifier"/>
+  <xs:complexType name="publication_identifier">
     <xs:simpleContent>
       <xs:extension base="xs:string">
+        <xs:attribute name="idx" type="xs:string"/>
         <xs:attribute name="type" use="required" type="xs:NCName"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:element name="related_identifier" type="long:related_identifier"/>
+  <xs:complexType name="related_identifier">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="idx" type="xs:string"/>
+        <xs:attribute name="type" use="required" type="xs:NCName"/>
+        <xs:attribute name="relationType" type="xs:string"/>
+        <xs:attribute name="resourceTypeGeneral" type="xs:string"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -331,4 +344,5 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:element name="hostCitation" type="xs:string"/>
+  <xs:element name="publicationYear" type="xs:string"/>
 </xs:schema>

--- a/meresco/xslt/cerif-orgunit.xsl
+++ b/meresco/xslt/cerif-orgunit.xsl
@@ -4,7 +4,8 @@
                 xmlns="https://www.openaire.eu/cerif-profile/1.1/"
                 exclude-result-prefixes="input xsi"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/org ../xsd/nod-organisation-1-1.xsd"
+                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/org ../xsd/nod-organisation-1-1.xsd
+                                    https://www.openaire.eu/cerif-profile/1.1/ https://www.openaire.eu/schema/cris/1.1/openaire-cerif-profile.xsd"
                 version="1.0">
 
     <!-- =================================================================================== -->

--- a/meresco/xslt/cerif-patent.xsl
+++ b/meresco/xslt/cerif-patent.xsl
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:input="http://www.knaw.nl/narcis/1.0/long/"
+                xmlns="https://www.openaire.eu/cerif-profile/1.1/"
+                exclude-result-prefixes="input xsi"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.knaw.nl/narcis/1.0/long/ ../xsd/knaw_long-1-1.xsd
+                                    https://www.openaire.eu/cerif-profile/1.1/ https://www.openaire.eu/schema/cris/1.1/openaire-cerif-profile.xsd"
+                version="1.0">
+
+    <!-- =================================================================================== -->
+    <xsl:output encoding="UTF-8" indent="yes" method="xml" omit-xml-declaration="yes"/>
+    <!-- =================================================================================== -->
+
+    <!-- variable -->
+
+    <xsl:template match="/">
+        <Patent>
+            <xsl:apply-templates select="input:knaw_long"/>
+        </Patent>
+    </xsl:template>
+
+    <xsl:template match="input:knaw_long">
+        <xsl:apply-templates select="input:uploadid"/>
+        <Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Patent_Types">http://purl.org/coar/resource_type/c_15cd</Type>
+        <xsl:apply-templates select="input:metadata"/>
+    </xsl:template>
+    
+    <xsl:template match="input:metadata">
+        <xsl:apply-templates select="input:titleInfo[not(@*)]"/>
+
+        <xsl:apply-templates select="input:dateIssued/input:parsed"/>
+        <xsl:apply-templates select="input:dateAccepted/input:parsed"/>
+
+        <xsl:apply-templates select="input:patent_number"/>
+
+        <Inventors>
+            <xsl:apply-templates select="input:name[input:mcRoleTerm='inv']"/>
+        </Inventors>
+
+        <Holders>
+            <xsl:apply-templates select="input:name[input:mcRoleTerm='pth']"/>
+        </Holders>
+
+        <xsl:apply-templates select="input:abstract[not(@*)]"/>
+
+        <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
+    </xsl:template>
+
+    <xsl:template match="input:uploadid">
+        <xsl:attribute name="id">
+            <xsl:value-of select="."/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <xsl:template match="input:titleInfo[not(@*)]">
+        <xsl:if test="input:title">
+            <Title xml:lang="en">
+                <xsl:value-of select="input:title"/>
+            </Title>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:dateIssued/input:parsed">
+        <xsl:if test=".">
+            <RegistrationDate>
+                <xsl:value-of select="."/>
+            </RegistrationDate>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:dateAccepted/input:parsed">
+        <xsl:if test=".">
+            <ApprovalDate>
+                <xsl:value-of select="."/>
+            </ApprovalDate>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:patent_number">
+        <xsl:if test=".">
+            <PatentNumber>
+                <xsl:value-of select="."/>
+            </PatentNumber>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:name">
+        <xsl:variable name="elementName">
+            <xsl:choose>
+                <xsl:when test="input:mcRoleTerm='inv'">Inventor</xsl:when>
+                <xsl:when test="input:mcRoleTerm='pth'">Holder</xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:element name="{$elementName}">
+            <xsl:call-template name="displayName"/>
+            <xsl:call-template name="person"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template name="displayName">
+        <DisplayName>
+            <xsl:choose>
+                <xsl:when test="./input:family or ./input:given">
+                    <xsl:value-of select="concat(./input:family, ', ', ./input:given)"/>
+                </xsl:when>
+                <xsl:when test="./input:unstructured">
+                    <xsl:value-of select="./input:unstructured"/>
+                </xsl:when>
+            </xsl:choose>
+        </DisplayName>
+    </xsl:template>
+    
+    <xsl:template name="person">
+        <Person>
+            <xsl:if test="input:nameIdentifier[@type='nod-prs']">
+                <xsl:attribute name="id">
+                    <xsl:value-of select="input:nameIdentifier[@type='nod-prs']"/>
+                </xsl:attribute>
+                <PersonName>
+                    <FamilyNames>
+                        <xsl:value-of select="./input:family"/>
+                    </FamilyNames>
+                    <FirstNames>
+                        <xsl:value-of select="./input:given"/>
+                    </FirstNames>
+                </PersonName>
+            </xsl:if>
+        </Person>
+    </xsl:template>
+
+    <xsl:template match="input:abstract[not(@*)]">
+        <xsl:if test=".">
+            <Abstract>
+                <xsl:value-of select="."/>
+            </Abstract>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:subject/input:topic/input:topicValue">
+        <xsl:if test=".">
+            <Keyword>
+                <xsl:value-of select="."/>
+            </Keyword>
+        </xsl:if>
+    </xsl:template>
+</xsl:stylesheet>

--- a/meresco/xslt/cerif-patent.xsl
+++ b/meresco/xslt/cerif-patent.xsl
@@ -25,7 +25,7 @@
         <Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Patent_Types">http://purl.org/coar/resource_type/c_15cd</Type>
         <xsl:apply-templates select="input:metadata"/>
     </xsl:template>
-    
+
     <xsl:template match="input:metadata">
         <xsl:apply-templates select="input:titleInfo[not(@*)]"/>
 
@@ -96,6 +96,9 @@
         <xsl:element name="{$elementName}">
             <xsl:call-template name="displayName"/>
             <xsl:call-template name="person"/>
+            <xsl:if test="input:mcRoleTerm='pth'"> <!-- only a patentholder may have an OrgUnit element -->
+                <xsl:call-template name="organisation"/>
+            </xsl:if>
         </xsl:element>
     </xsl:template>
 
@@ -111,23 +114,40 @@
             </xsl:choose>
         </DisplayName>
     </xsl:template>
-    
+
     <xsl:template name="person">
-        <Person>
-            <xsl:if test="input:nameIdentifier[@type='nod-prs']">
-                <xsl:attribute name="id">
-                    <xsl:value-of select="input:nameIdentifier[@type='nod-prs']"/>
-                </xsl:attribute>
-                <PersonName>
-                    <FamilyNames>
-                        <xsl:value-of select="./input:family"/>
-                    </FamilyNames>
-                    <FirstNames>
-                        <xsl:value-of select="./input:given"/>
-                    </FirstNames>
-                </PersonName>
-            </xsl:if>
-        </Person>
+        <xsl:if test="input:type='personal'">
+            <Person>
+                <xsl:if test="input:nameIdentifier[@type='nod-prs']">
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="input:nameIdentifier[@type='nod-prs']"/>
+                    </xsl:attribute>
+                    <PersonName>
+                        <FamilyNames>
+                            <xsl:value-of select="./input:family"/>
+                        </FamilyNames>
+                        <FirstNames>
+                            <xsl:value-of select="./input:given"/>
+                        </FirstNames>
+                    </PersonName>
+                </xsl:if>
+            </Person>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="organisation">
+        <xsl:if test="input:type='corporate'">
+            <OrgUnit>
+                <xsl:if test="input:nameIdentifier[@type='nod-org']">
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="input:nameIdentifier[@type='nod-org']"/>
+                    </xsl:attribute>
+                    <Name xml:lang="en">
+                        <xsl:value-of select="input:unstructured"/>
+                    </Name>
+                </xsl:if>
+            </OrgUnit>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="input:abstract[not(@*)]">

--- a/meresco/xslt/cerif-patent.xsl
+++ b/meresco/xslt/cerif-patent.xsl
@@ -34,13 +34,17 @@
 
         <xsl:apply-templates select="input:patent_number"/>
 
-        <Inventors>
-            <xsl:apply-templates select="input:name[input:mcRoleTerm='inv']"/>
-        </Inventors>
+        <xsl:if test="input:name[input:mcRoleTerm='inv']">
+            <Inventors>
+                <xsl:apply-templates select="input:name[input:mcRoleTerm='inv']"/>
+            </Inventors>
+        </xsl:if>
 
-        <Holders>
-            <xsl:apply-templates select="input:name[input:mcRoleTerm='pth']"/>
-        </Holders>
+        <xsl:if test="input:name[input:mcRoleTerm='pth']">
+            <Holders>
+                <xsl:apply-templates select="input:name[input:mcRoleTerm='pth']"/>
+            </Holders>
+        </xsl:if>
 
         <xsl:apply-templates select="input:abstract[not(@*)]"/>
 

--- a/meresco/xslt/cerif-person.xsl
+++ b/meresco/xslt/cerif-person.xsl
@@ -4,7 +4,8 @@
                 xmlns="https://www.openaire.eu/cerif-profile/1.1/"
                 exclude-result-prefixes="input xsi"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/prs ../xsd/nod-person-1-1.xsd"
+                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/prs ../xsd/nod-person-1-1.xsd
+                                    https://www.openaire.eu/cerif-profile/1.1/ https://www.openaire.eu/schema/cris/1.1/openaire-cerif-profile.xsd"
                 version="1.0">
 
     <!-- =================================================================================== -->

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:input="http://www.knaw.nl/narcis/1.0/long/"
+                xmlns="https://www.openaire.eu/cerif-profile/1.1/"
+                exclude-result-prefixes="input xsi"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.knaw.nl/narcis/1.0/long/ ../xsd/knaw_long-1-1.xsd
+                                    https://www.openaire.eu/cerif-profile/1.1/ https://www.openaire.eu/schema/cris/1.1/openaire-cerif-profile.xsd"
+                version="1.0">
+
+    <!-- =================================================================================== -->
+    <xsl:output encoding="UTF-8" indent="yes" method="xml" omit-xml-declaration="yes"/>
+    <!-- =================================================================================== -->
+
+    <!-- variable -->
+
+    <xsl:template match="/">
+        <Product>
+            <xsl:apply-templates select="input:knaw_long"/>
+        </Product>
+    </xsl:template>
+
+    <xsl:template match="input:knaw_long">
+        <xsl:apply-templates select="input:uploadid"/>
+        <xsl:apply-templates select="input:metadata"/>
+        <xsl:apply-templates select="input:accessRights"/>
+    </xsl:template>
+
+    <xsl:template match="input:metadata">
+        <xsl:call-template name="product-type"/>
+
+        <xsl:apply-templates select="input:language"/>
+        <xsl:apply-templates select="input:titleInfo[not(@*)]"/>
+
+        <xsl:apply-templates select="input:publication_identifier"/>
+
+        <Creators>
+            <xsl:apply-templates select="input:name[input:mcRoleTerm='cre']"/>
+        </Creators>
+        
+        <xsl:apply-templates select="input:rightsDescription"/>
+        <xsl:apply-templates select="input:abstract[not(@*)]"/>
+        
+        <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
+    </xsl:template>
+
+    <xsl:template match="input:uploadid">
+        <xsl:attribute name="id">
+            <xsl:value-of select="."/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <xsl:template name="product-type">
+        <Type>
+            <xsl:choose>
+                <xsl:when test="input:genre='software'">
+                    <xsl:value-of select="'http://purl.org/coar/resource_type/c_5ce6'"/>
+                    <xsl:comment xml:space="preserve"> software </xsl:comment>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="'http://purl.org/coar/resource_type/c_ddb1'"/>
+                    <xsl:comment xml:space="preserve"> dataset </xsl:comment>
+                </xsl:otherwise>
+            </xsl:choose>
+        </Type>
+    </xsl:template>
+
+    <xsl:template match="input:language">
+        <xsl:if test=".">
+            <Language>
+                <xsl:value-of select="."/>
+            </Language>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="input:titleInfo[not(@*)]">
+        <xsl:if test="input:title">
+            <Title xml:lang="en">
+                <xsl:value-of select="input:title"/>
+            </Title>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:publication_identifier">
+        <xsl:variable name="elementName">
+            <xsl:choose>
+                <xsl:when test="@type='doi'">DOI</xsl:when>
+                <xsl:when test="@type='hdl'">Handle</xsl:when>
+                <xsl:when test="@type='purl'">URL</xsl:when>
+                <xsl:when test="@type='nbn'">URN</xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test=".">
+            <xsl:element name="{$elementName}">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:name">
+        <xsl:variable name="elementName">
+            <xsl:choose>
+                <xsl:when test="input:mcRoleTerm='cre'">Creator</xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:element name="{$elementName}">
+            <xsl:call-template name="displayName"/>
+            <xsl:call-template name="person"/>
+            <xsl:call-template name="organisation"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template name="displayName">
+        <DisplayName>
+            <xsl:choose>
+                <xsl:when test="./input:family or ./input:given">
+                    <xsl:value-of select="concat(./input:family, ', ', ./input:given)"/>
+                </xsl:when>
+                <xsl:when test="./input:unstructured">
+                    <xsl:value-of select="./input:unstructured"/>
+                </xsl:when>
+            </xsl:choose>
+        </DisplayName>
+    </xsl:template>
+
+    <xsl:template name="person">
+        <xsl:if test="input:type='personal'">
+            <Person>
+                <xsl:if test="input:nameIdentifier[@type='nod-prs']">
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="input:nameIdentifier[@type='nod-prs']"/>
+                    </xsl:attribute>
+                    <PersonName>
+                        <FamilyNames>
+                            <xsl:value-of select="./input:family"/>
+                        </FamilyNames>
+                        <FirstNames>
+                            <xsl:value-of select="./input:given"/>
+                        </FirstNames>
+                    </PersonName>
+                </xsl:if>
+            </Person>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="organisation">
+        <xsl:if test="input:type='corporate'">
+            <OrgUnit>
+                <xsl:if test="input:nameIdentifier[@type='nod-org']">
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="input:nameIdentifier[@type='nod-org']"/>
+                    </xsl:attribute>
+                    <Name xml:lang="en">
+                        <xsl:value-of select="input:unstructured"/>
+                    </Name>
+                </xsl:if>
+            </OrgUnit>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:rightsDescription">
+        <xsl:if test=".">
+            <License scheme="http://www.narcis.nl/cerif-profile/vocab/LicenseType"> <!-- TODO scheme needs to be filled in if available -->
+                <xsl:value-of select="."/>
+            </License>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:abstract[not(@*)]">
+        <xsl:if test=".">
+            <Abstract>
+                <xsl:value-of select="."/>
+            </Abstract>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:subject/input:topic/input:topicValue">
+        <xsl:if test=".">
+            <Keyword>
+                <xsl:value-of select="."/>
+            </Keyword>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="input:accessRights">
+        <Access xmlns="http://purl.org/coar/access_right">
+            <xsl:choose>
+                <xsl:when test=".='openAccess'">
+                    <xsl:value-of select="'http://purl.org/coar/access_right/c_abf2'"/>
+                    <xsl:comment xml:space="preserve"> open access </xsl:comment>
+                </xsl:when>
+                <xsl:when test=".='embargoedAccess'">
+                    <xsl:value-of select="'http://purl.org/coar/access_right/c_f1cf'"/>
+                    <xsl:comment xml:space="preserve"> embargoed access </xsl:comment>
+                </xsl:when>
+                <xsl:when test=".='restrictedAccess'">
+                    <xsl:value-of select="'http://purl.org/coar/access_right/c_16ec'"/>
+                    <xsl:comment xml:space="preserve"> restricted access </xsl:comment>
+                </xsl:when>
+                <xsl:when test=".='closedAccess'">
+                    <xsl:value-of select="'http://purl.org/coar/access_right/c_14cb'"/>
+                    <xsl:comment xml:space="preserve"> metadata only access </xsl:comment>
+                </xsl:when>
+            </xsl:choose>
+        </Access>
+    </xsl:template>
+</xsl:stylesheet>

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -34,13 +34,15 @@
 
         <xsl:apply-templates select="input:publication_identifier"/>
 
-        <Creators>
-            <xsl:apply-templates select="input:name[input:mcRoleTerm='cre']"/>
-        </Creators>
-        
+        <xsl:if test="input:name[input:mcRoleTerm='cre']">
+            <Creators>
+                <xsl:apply-templates select="input:name[input:mcRoleTerm='cre']"/>
+            </Creators>
+        </xsl:if>
+
         <xsl:apply-templates select="input:rightsDescription"/>
         <xsl:apply-templates select="input:abstract[not(@*)]"/>
-        
+
         <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
     </xsl:template>
 
@@ -72,7 +74,7 @@
             </Language>
         </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="input:titleInfo[not(@*)]">
         <xsl:if test="input:title">
             <Title xml:lang="en">

--- a/meresco/xslt/cerif-project.xsl
+++ b/meresco/xslt/cerif-project.xsl
@@ -35,17 +35,21 @@
         <xsl:apply-templates select="input:startdate"/>
         <xsl:apply-templates select="input:enddate"/>
 
-        <Consortium>
-            <xsl:apply-templates select="input:penvoerder"/>
+        <xsl:if test="input:penvoerder or input:samenwerking or input:opdrachtgever">
+            <Consortium>
+                <xsl:apply-templates select="input:penvoerder"/>
 
-            <xsl:apply-templates select="input:samenwerking"/>
+                <xsl:apply-templates select="input:samenwerking"/>
 
-            <xsl:apply-templates select="input:opdrachtgever"/>
-        </Consortium>
+                <xsl:apply-templates select="input:opdrachtgever"/>
+            </Consortium>
+        </xsl:if>
 
-        <Team>
-            <xsl:apply-templates select="input:person"/>
-        </Team>
+        <xsl:if test="input:person">
+            <Team>
+                <xsl:apply-templates select="input:person"/>
+            </Team>
+        </xsl:if>
 
         <xsl:apply-templates select="input:financier"/>
 

--- a/meresco/xslt/cerif-project.xsl
+++ b/meresco/xslt/cerif-project.xsl
@@ -4,7 +4,8 @@
                 xmlns="https://www.openaire.eu/cerif-profile/1.1/"
                 exclude-result-prefixes="input xsi"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/act ../xsd/nod-research-1-1.xsd"
+                xsi:schemaLocation="http://www.onderzoekinformatie.nl/nod/act ../xsd/nod-research-1-1.xsd
+                                    https://www.openaire.eu/cerif-profile/1.1/ https://www.openaire.eu/schema/cris/1.1/openaire-cerif-profile.xsd"
                 version="1.0">
 
     <!-- =================================================================================== -->


### PR DESCRIPTION
* [x] add `uploadid` and `patent_number` to `knaw_long` xsd
    * also added already existing elements to `knaw_long` xsd, because they were missing
    * added `nod-org` name identifier
* [x] add openaire scheme to existing XSLTs
* [x] patent XSLT
* [x] product XSLT (including dataset and software)
* [ ] publication XSLT

@wilkos-dans @DANS-KNAW/narcis for review

**Actions to be taken after merging this PR:**
* [ ] implement `nod-org` identifier in Meresco, similar to `nod-prs`