### PR TITLE
ignoring any other publication_identifier

### DIFF
--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -32,7 +32,11 @@
         <xsl:apply-templates select="input:language"/>
         <xsl:apply-templates select="input:titleInfo[not(@*)]"/>
 
-        <xsl:apply-templates select="input:publication_identifier"/>
+        <xsl:apply-templates select="input:publication_identifier[@type='doi']"/>
+        <xsl:apply-templates select="input:publication_identifier[@type='hdl']"/>
+        <xsl:apply-templates select="input:publication_identifier[@type='purl']"/>
+        <xsl:apply-templates select="input:publication_identifier[@type='nbn']"/>
+        <xsl:apply-templates select="input:publication_identifier[@type='urn']"/>
 
         <xsl:if test="input:name[input:mcRoleTerm='cre']">
             <Creators>
@@ -84,8 +88,6 @@
     </xsl:template>
 
     <xsl:template match="input:publication_identifier">
-        <xsl:variable name="IGNORE_OTHER_IDENTIFIERS">IGNORE_OTHER_IDENTIFIERS</xsl:variable>
-
         <xsl:variable name="elementName">
             <xsl:choose>
                 <xsl:when test="@type='doi'">DOI</xsl:when>
@@ -93,13 +95,10 @@
                 <xsl:when test="@type='purl'">URL</xsl:when>
                 <xsl:when test="@type='nbn'">URN</xsl:when>
                 <xsl:when test="@type='urn'">URN</xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="$IGNORE_OTHER_IDENTIFIERS"/>
-                </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
 
-        <xsl:if test=". and $elementName != $IGNORE_OTHER_IDENTIFIERS">
+        <xsl:if test=".">
             <xsl:element name="{$elementName}">
                 <xsl:value-of select="."/>
             </xsl:element>

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -84,6 +84,8 @@
     </xsl:template>
 
     <xsl:template match="input:publication_identifier">
+        <xsl:variable name="IGNORE_OTHER_IDENTIFIERS">IGNORE_OTHER_IDENTIFIERS</xsl:variable>
+
         <xsl:variable name="elementName">
             <xsl:choose>
                 <xsl:when test="@type='doi'">DOI</xsl:when>
@@ -91,11 +93,13 @@
                 <xsl:when test="@type='purl'">URL</xsl:when>
                 <xsl:when test="@type='nbn'">URN</xsl:when>
                 <xsl:when test="@type='urn'">URN</xsl:when>
-                <xsl:otherwise>ID</xsl:otherwise>
+                <xsl:otherwise>
+                    <xsl:value-of select="$IGNORE_OTHER_IDENTIFIERS"/>
+                </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
 
-        <xsl:if test=".">
+        <xsl:if test=". and $elementName != $IGNORE_OTHER_IDENTIFIERS">
             <xsl:element name="{$elementName}">
                 <xsl:value-of select="."/>
             </xsl:element>


### PR DESCRIPTION
If the `@type` of the `publication_identifier` doesn't match any of the given strings, ignore the identifier in the transformation to OpenAIRE-CERIF.

@DANS-KNAW/narcis for review
@lindareijnhoudt as you are more familiar with XSLT, would you say this is a good solution? Or do you know of a better one?