### PR TITLE
CERIF bug fixes

### DIFF
--- a/meresco/xslt/cerif-patent.xsl
+++ b/meresco/xslt/cerif-patent.xsl
@@ -167,7 +167,7 @@
 
     <xsl:template match="input:subject/input:topic/input:topicValue">
         <xsl:if test=".">
-            <Keyword>
+            <Keyword xml:lang="en">
                 <xsl:value-of select="."/>
             </Keyword>
         </xsl:if>

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -185,7 +185,7 @@
 
     <xsl:template match="input:subject/input:topic/input:topicValue">
         <xsl:if test=".">
-            <Keyword>
+            <Keyword xml:lang="en">
                 <xsl:value-of select="."/>
             </Keyword>
         </xsl:if>

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -177,12 +177,9 @@
 
     <xsl:template match="input:abstract[not(@*)]">
         <xsl:if test=".">
-            <Abstract>
-                <xsl:attribute name="xml:lang">
-                    <xsl:value-of select="'en'"/>
-                </xsl:attribute>
+            <Description xml:lang="en">
                 <xsl:value-of select="."/>
-            </Abstract>
+            </Description>
         </xsl:if>
     </xsl:template>
 

--- a/meresco/xslt/cerif-product.xsl
+++ b/meresco/xslt/cerif-product.xsl
@@ -81,9 +81,9 @@
 
     <xsl:template match="input:titleInfo[not(@*)]">
         <xsl:if test="input:title">
-            <Title xml:lang="en">
+            <Name xml:lang="en">
                 <xsl:value-of select="input:title"/>
-            </Title>
+            </Name>
         </xsl:if>
     </xsl:template>
 

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -65,8 +65,6 @@
 
         <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
         <xsl:apply-templates select="input:abstract"/>
-
-        <!-- TODO continue here with more metadata elements -->
     </xsl:template>
 
     <xsl:template name="publication-type">

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -65,8 +65,7 @@
 
         <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
         <xsl:apply-templates select="input:abstract"/>
-        
-        <Status scheme="http://vocabularies.coar-repositories.org/documentation/version_types/">http://purl.org/coar/version/c_be7fb7dd8ff6fe43<!-- Not Applicable (or Unknown) --></Status>
+                
     </xsl:template>
 
     <xsl:template name="publication-type">

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -23,7 +23,6 @@
     <xsl:template match="input:knaw_long">
         <xsl:apply-templates select="input:uploadid"/>
         <xsl:apply-templates select="input:metadata"/>
-        <xsl:apply-templates select="input:persistentIdentifier"/>
         <xsl:apply-templates select="input:accessRights"/>
     </xsl:template>
 
@@ -56,6 +55,7 @@
         <xsl:apply-templates select="input:publication_identifier[@type='isbn']"/>
 
         <xsl:apply-templates select="input:location_url"/>
+        <xsl:apply-templates select="../input:persistentIdentifier"/>
 
         <xsl:if test="input:name[input:mcRoleTerm='aut']">
             <Authors>

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -65,6 +65,8 @@
 
         <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
         <xsl:apply-templates select="input:abstract"/>
+        
+<!--     TODO for wilkosdans <Status></Status>-->
     </xsl:template>
 
     <xsl:template name="publication-type">

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -364,7 +364,7 @@
 
     <xsl:template match="input:subject/input:topic/input:topicValue">
         <xsl:if test=".">
-            <Keyword>
+            <Keyword xml:lang="en">
                 <xsl:value-of select="."/>
             </Keyword>
         </xsl:if>

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -66,7 +66,7 @@
         <xsl:apply-templates select="input:subject/input:topic/input:topicValue"/>
         <xsl:apply-templates select="input:abstract"/>
         
-<!--     TODO for wilkosdans <Status></Status>-->
+        <Status scheme="http://vocabularies.coar-repositories.org/documentation/version_types/">http://purl.org/coar/version/c_be7fb7dd8ff6fe43<!-- Not Applicable (or Unknown) --></Status>
     </xsl:template>
 
     <xsl:template name="publication-type">

--- a/meresco/xslt/cerif-publication.xsl
+++ b/meresco/xslt/cerif-publication.xsl
@@ -39,7 +39,7 @@
         <xsl:apply-templates select="input:titleInfo[not(@*)]/input:title"/>
         <xsl:apply-templates select="input:titleInfo[not(@*)]/input:subtitle"/>
 
-        <xsl:apply-templates select="input:relatedItem[@type='host']/input:titleInfo[not(@*)]/input:title"/>
+        <xsl:call-template name="publishedIn"/>
         <xsl:apply-templates select="input:dateIssued/input:parsed"/>
         <xsl:apply-templates select="input:relatedItem[@type='host']/input:part/input:volume"/>
         <xsl:apply-templates select="input:relatedItem[@type='host']/input:part/input:issue"/>
@@ -202,10 +202,63 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="input:relatedItem[@type='host']/input:titleInfo[not(@*)]/input:title" priority="5">
-        <xsl:if test=".">
+    <xsl:template name="publishedIn">
+        <xsl:if test="input:relatedItem[@type='host']/input:titleInfo[not(@*)]/input:title">
             <PublishedIn>
-                <xsl:value-of select="."/>
+                <Publication>
+                    <Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">
+                        <xsl:choose>
+                            <xsl:when test="input:genre='annotation'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='article'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='bookpart'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_2f33'"/>
+                                <xsl:comment xml:space="preserve"> book </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='bookreview'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='conferencepaper'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_f744'"/>
+                                <xsl:comment xml:space="preserve"> conference proceedings </xsl:comment>
+                            </xsl:when>
+
+                            <xsl:when test="input:genre='contributiontoperiodical'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='preprint'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='workingpaper'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='reportpart'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_93fc'"/>
+                                <xsl:comment xml:space="preserve"> report </xsl:comment>
+                            </xsl:when>
+                            <xsl:when test="input:genre='review'">
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_0640'"/>
+                                <xsl:comment xml:space="preserve"> journal </xsl:comment>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="'http://purl.org/coar/resource_type/c_18cf'"/>
+                                <xsl:comment xml:space="preserve"> text </xsl:comment>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </Type>
+                    <Title xml:lang="en">
+                        <xsl:value-of select="input:relatedItem[@type='host']/input:titleInfo[not(@*)]/input:title"/>
+                    </Title>
+                </Publication>
             </PublishedIn>
         </xsl:if>
     </xsl:template>


### PR DESCRIPTION
fixes a number of bugs found by @wilkos-dans in running the CERIF validator on a testset:

* `product`: rename `Title` element to `Name`
* `product`: rename `Abstract` element to `Description`
* `product`, `patent` and `publication`: `add `xml:lang="en"` attribute to `Keyword` element
* `publication`: move the `URN` element to the correct place
* `publication`: remove an old TODO comment
* `publication`: `PublishedIn` requires a `Publication` element inside with at least an identifier, rather than the currently provided journal title. We have sent an email to Andreas and Jochen about this, asking them to expand the schema with a `DisplayName` element as they did for authors as well, because we don't have an identifier for journals

@DANS-KNAW/narcis for review