### PR TITLE
NARCIS-1353: Funding uit DC toevoegen (Donders Institute)

### DIFF
--- a/meresco/dans/longconverter.py
+++ b/meresco/dans/longconverter.py
@@ -1299,8 +1299,6 @@ class NormaliseOaiRecord(UiaConverter):
                     if fundingIdRegex.match(fundingId):
                         etree.SubElement(e_ga, "code").text = fundingId
 
-
-
         elif self._metadataformat.isMods():
             e_gas = None
             #Look for grantAgreements with mandatory Project Reference (@code)
@@ -1345,6 +1343,16 @@ class NormaliseOaiRecord(UiaConverter):
             if e_gas is not None:
                 e_longmetadata.append(e_gas)
 
+        elif self._metadataformat.isDC():
+            relations = lxmlNode.xpath("//dc:relation/text()", namespaces=namespacesmap)
+            if "info:eu-repo/grantAgreement" in str(relations):
+                e_gas = etree.SubElement(e_longmetadata, "grantAgreements")
+                for relation in relations:
+                    if relation.startswith("info:eu-repo/grantAgreement"):
+                        fundingId = relation
+                        if fundingIdRegex.match(fundingId):
+                            e_ga = etree.SubElement(e_gas, "grantAgreement")
+                            etree.SubElement(e_ga, "code").text = fundingId
 
     def _getGeoLocations(self, lxmlNode, e_longmetadata):
         if self._metadataformat.isDatacite():

--- a/test/_integration/apitest.py
+++ b/test/_integration/apitest.py
@@ -269,6 +269,7 @@ class ApiTest(IntegrationTestCase):
         self.assertEqual('10.1002/lno.10611', testNamespaces.xpathFirst(response, '//long:metadata/long:publication_identifier/text()'))
         self.assertEqual(2, len(testNamespaces.xpath(response, '//long:metadata/long:related_identifier')))
         self.assertEqual('10.1234.567/abc', testNamespaces.xpathFirst(response, '//long:metadata/long:related_identifier/text()'))
+        self.assertEqual('info:eu-repo/grantAgreement/NWO/Gravitation/024.001.006', testNamespaces.xpathFirst(response, '//long:metadata/long:grantAgreements/long:grantAgreement/long:code/text()'))
 
     def testDidlDcToLong(self):
         response = self.doSruQuery(**{'query': '2016-01-31', 'recordSchema':'knaw_long'})

--- a/test/data/0010_dc_pub_meresco_record_1.updateRequest
+++ b/test/data/0010_dc_pub_meresco_record_1.updateRequest
@@ -24,6 +24,7 @@
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/altIdentifier/wos/000423029300003&lt;/dc:relation&gt;
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/dataset/doi/10.1234.567/abc&lt;/dc:relation&gt;
             &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/semantics/reference/urn/urn:nbn:nl:ui:19-4567890&lt;/dc:relation&gt;
+            &lt;dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;info:eu-repo/grantAgreement/NWO/Gravitation/024.001.006&lt;/dc:relation&gt;
             &lt;/oai_dc:dc&gt;&lt;/metadata&gt;
             &lt;/record&gt;</part>
             <part name="meta">&lt;meta xmlns=&quot;http://meresco.org/namespace/harvester/meta&quot;&gt;


### PR DESCRIPTION
fixes: NARCIS-1353

When applied it will:
* add `<dc:relation> `field value as `GrantAgreement funding id` (`code`) in knaw_long for `DC` records, when the value starts with `info:eu-repo/grantAgreement`